### PR TITLE
Added nvidia GPU support

### DIFF
--- a/go_node_engine/build/install.sh
+++ b/go_node_engine/build/install.sh
@@ -12,7 +12,7 @@ if [ ! $? -eq 0 ]; then
 fi
 
 #check containerd installation
-if systemctl | grep -Fq 'containerd'; then
+if sudo systemctl | grep -Fq 'containerd'; then
   sudo systemctl daemon-reload
   sudo systemctl enable --now containerd
 else

--- a/go_node_engine/model/Service.go
+++ b/go_node_engine/model/Service.go
@@ -1,15 +1,16 @@
 package model
 
 type Service struct {
-	JobID        string   `json:"_id"`
-	Sname        string   `json:"job_name"`
-	Image        string   `json:"image"`
-	Commands     []string `json:"commands"`
-	Env          []string `json:"environment"`
-	Ports        string   `json:"port"`
-	Status       string   `json:"status"`
-	Runtime      string   `json:"image_runtime"`
-	StatusDetail string   `json:"status_detail"`
+	JobID        string                 `json:"_id"`
+	Sname        string                 `json:"job_name"`
+	Image        string                 `json:"image"`
+	Commands     []string               `json:"commands"`
+	Env          []string               `json:"environment"`
+	Ports        string                 `json:"port"`
+	Status       string                 `json:"status"`
+	Runtime      string                 `json:"image_runtime"`
+	StatusDetail string                 `json:"status_detail"`
+	Requirements map[string]interface{} `json:"requirements"`
 	Pid          int
 }
 

--- a/go_node_engine/virtualization/ContainersManagement.go
+++ b/go_node_engine/virtualization/ContainersManagement.go
@@ -7,6 +7,7 @@ import (
 	"github.com/containerd/containerd"
 	"github.com/containerd/containerd/cio"
 	"github.com/containerd/containerd/containers"
+	"github.com/containerd/containerd/contrib/nvidia"
 	"github.com/containerd/containerd/namespaces"
 	"github.com/containerd/containerd/oci"
 	"github.com/opencontainers/runtime-spec/specs-go"
@@ -165,6 +166,14 @@ func (r *ContainerRuntime) containerCreationRoutine(
 	//add user defined commands
 	if len(service.Commands) > 0 {
 		specOpts = append(specOpts, oci.WithProcessArgs(service.Commands...))
+	}
+	//add GPU if needed
+	if val, ok := service.Requirements["gpu"]; ok {
+		value := fmt.Sprintf("%v", val)
+		if value != "0" {
+			specOpts = append(specOpts, nvidia.WithGPUs(nvidia.WithDevices(0), nvidia.WithAllCapabilities))
+			logger.InfoLogger().Printf("NVIDIA - Adding GPU driver")
+		}
 	}
 	//add resolve file with default google dns
 	resolvconfFile, err := getGoogleDNSResolveConf()


### PR DESCRIPTION
using "gpu: 1 "requirement the go ndoe engine creates the container using the Nvidia driver.

We still need to propagate the presence of the driver and configure the schedulers to include this constraint as well.  