### PR TITLE
Fix schema to allow descriptions-less apps

### DIFF
--- a/root_orchestrator/system-manager-python/ext_requests/apps_db.py
+++ b/root_orchestrator/system-manager-python/ext_requests/apps_db.py
@@ -187,7 +187,7 @@ def mongo_update_application(app_id, userid, data):
     db.mongo_applications.find_one_and_update({'_id': ObjectId(app_id), 'userId': userid},
                                               {'$set': {'application_name': data.get('application_name'),
                                                         'application_namespace': data.get('application_namespace'),
-                                                        'application_desc': data.get('application_desc'),
+                                                        'application_desc': data.get('application_desc', ""),
                                                         'microservices': data.get('microservices')}})
 
     db.app.logger.info("MONGODB - application {} updated")

--- a/root_orchestrator/system-manager-python/sla/schema.py
+++ b/root_orchestrator/system-manager-python/sla/schema.py
@@ -122,7 +122,7 @@ sla_schema = {
                         "exclusiveMinimum": 0,
                     },
                 },
-                "required": ["applicationID", "application_name", "application_desc", "microservices"],
+                "required": ["applicationID", "application_name", "microservices"],
             }
         },
         "args": {

--- a/root_orchestrator/system-manager-python/tests/service_level_agreements/sla_correct_3.json
+++ b/root_orchestrator/system-manager-python/tests/service_level_agreements/sla_correct_3.json
@@ -1,0 +1,35 @@
+{
+  "sla_version" : "v2.0",
+  "customerID" : "Admin",
+  "applications" : [
+    {
+      "applicationID": "627527c1a4a5edb43d085f37",
+      "application_name": "test",
+      "application_namespace": "test",
+      "microservices": [
+        {
+          "microserviceID": "",
+          "microservice_name": "test",
+          "microservice_namespace": "test",
+          "virtualization": "container",
+          "memory": 0,
+          "vcpus": 0,
+          "vgpus": 0,
+          "vtpus": 0,
+          "bandwidth_in": 0,
+          "bandwidth_out": 0,
+          "storage": 0,
+          "code": "docker.io/library/nginx",
+          "state": "",
+          "port": "80:80",
+          "cmd": [
+            "ls"
+          ],
+          "added_files": [],
+          "constraints": [],
+          "connectivity": []
+        }
+      ]
+    }
+  ]
+}

--- a/root_orchestrator/system-manager-python/tests/sla_test.py
+++ b/root_orchestrator/system-manager-python/tests/sla_test.py
@@ -1,45 +1,46 @@
+import pathlib
 import unittest
-import os.path
-from sla.versioned_sla_parser import parse_sla_json
+
+from sla.versioned_sla_parser import SLAFormatError, parse_sla_json
+
+TEST_SLAS_PATH = pathlib.Path.cwd() / "tests" / "service_level_agreements"
+
+
+# Note: helper functions for unit tests need to start with a different prefix than "test_"
+def aux_test_correct_sla(self: unittest.TestCase, correct_test_sla_id: int) -> None:
+    with open(TEST_SLAS_PATH / f"sla_correct_{correct_test_sla_id}.json", "r") as f:
+        self.assertTrue(parse_sla_json(f.read()))
+
+
+def aux_test_flawed_sla(
+    self: unittest.TestCase, flawed_test_sla_id: int, exception_type: BaseException
+) -> None:
+    with open(TEST_SLAS_PATH / f"sla_flawed_{flawed_test_sla_id}.json", "r") as f:
+        try:
+            parse_sla_json(f.read())
+        except exception_type:
+            return
+        self.fail("Exception expected")
 
 
 class SLATestCase(unittest.TestCase):
     def test_correct_1(self):
-        f = open(os.path.join(os.getcwd(), "tests/service_level_agreements/sla_correct_1.json"), "r")
-        self.assertTrue(parse_sla_json(f.read()))
+        aux_test_correct_sla(self, 1)
 
     def test_correct_2(self):
-        f = open(os.path.join(os.getcwd(), "tests/service_level_agreements/sla_correct_2.json"), "r")
-        self.assertTrue(parse_sla_json(f.read()))
+        aux_test_correct_sla(self, 2)
+
+    def test_correct_3(self):
+        aux_test_correct_sla(self, 3)
 
     def test_flawed_1(self):
-        f = open(os.path.join(os.getcwd(), "tests/service_level_agreements/sla_flawed_1.json"), "r")
-        try:
-            parse_sla_json(f.read())
-        except:
-            return
-        self.fail("Exception expected")
+        aux_test_flawed_sla(self, 1, KeyError)
 
     def test_flawed_2(self):
-        f = open(os.path.join(os.getcwd(), "tests/service_level_agreements/sla_flawed_2.json"), "r")
-        try:
-            parse_sla_json(f.read())
-        except:
-            return
-        self.fail("Exception expected")
+        aux_test_flawed_sla(self, 2, SLAFormatError)
 
     def test_flawed_3(self):
-        f = open(os.path.join(os.getcwd(), "tests/service_level_agreements/sla_flawed_3.json"), "r")
-        try:
-            parse_sla_json(f.read())
-        except:
-            return
-        self.fail("Exception expected")
+        aux_test_flawed_sla(self, 3, KeyError)
 
     def test_flawed_4(self):
-        f = open(os.path.join(os.getcwd(), "tests/service_level_agreements/sla_flawed_4.json"), "r")
-        try:
-            parse_sla_json(f.read())
-        except:
-            return
-        self.fail("Exception expected")
+        aux_test_flawed_sla(self, 4, SLAFormatError)


### PR DESCRIPTION
Resolves this issue: https://github.com/oakestra/dashboard/issues/37

Demo: Seems to be working:
https://github.com/oakestra/oakestra/assets/65814168/3ed81f59-657e-43d6-a878-e0d59ae02681

Regarding other occurrences of "application_desc"
![image](https://github.com/oakestra/oakestra/assets/65814168/e05e28d9-79b8-492f-9eda-11494b2f7921)

The only IMO interesting other place is here:

```python
def mongo_update_application(app_id, userid, data):
    db.app.logger.info("MONGODB - update data...")
    db.mongo_applications.find_one_and_update({'_id': ObjectId(app_id), 'userId': userid},
                                              {'$set': {'application_name': data.get('application_name'),
                                                        'application_namespace': data.get('application_namespace'),
                                                        'application_desc': data.get('application_desc'),
                                                        'microservices': data.get('microservices')}})
```

From my understanding `data.get('application_desc')` should not lead to issues because the get() method is a dictionary method that returns the default value (usually None) if the key is not found.
