### PR TITLE
Shrink system-manager image size

### DIFF
--- a/root_orchestrator/system-manager-python/Dockerfile
+++ b/root_orchestrator/system-manager-python/Dockerfile
@@ -1,9 +1,9 @@
-FROM python:3.10
+FROM python:3.10-alpine
 LABEL org.opencontainers.image.source https://github.com/oakestra/oakestra
 
 ADD requirements.txt /
 
-RUN pip install -r requirements.txt
+RUN pip install -r requirements.txt --no-cache-dir && rm /requirements.txt
 
 ADD . /
 


### PR DESCRIPTION
See this ticket for a detailed explanation: https://github.com/oakestra/oakestra/issues/61#issuecomment-1761519336

Let's try it out with alpine & busybox.
If it turns out to be too uncomfortable to debug we can simply switch to "slim" instead.