### PR TITLE
Fix system-manager-python Docker image build

### DIFF
--- a/root_orchestrator/system-manager-python/Dockerfile
+++ b/root_orchestrator/system-manager-python/Dockerfile
@@ -1,5 +1,8 @@
-FROM python:3.10-slim
+FROM python:3.10-slim-buster
 LABEL org.opencontainers.image.source https://github.com/oakestra/oakestra
+
+# The greenlet pip package requires gcc & g++ to work properly.
+RUN apt-get update && apt-get install -y --no-install-recommends gcc g++
 
 ADD requirements.txt /
 


### PR DESCRIPTION
Fixes the following issue:
![image](https://github.com/oakestra/oakestra/assets/65814168/c30e7163-2d3d-4ab1-80e8-c7659ec6d20c)
![image](https://github.com/oakestra/oakestra/assets/65814168/0f74762a-fbf7-41de-b568-e2d49e634194)
![image](https://github.com/oakestra/oakestra/assets/65814168/43b36ffa-f9e6-4f42-9403-8b0fd5ad71fb)
![image](https://github.com/oakestra/oakestra/assets/65814168/006d224d-228e-441d-95b8-01a7dfb58b25)
Log: https://github.com/oakestra/oakestra/actions/runs/7085706626/job/19411364416rl

Resolves this: https://github.com/oakestra/oakestra/issues/61#issuecomment-1845368687

The issue was that the greenlet pip package requires gcc & g++ to work properly which were missing in the 3.10-slim or even 3.10-slim-buster base image but present in the large/previous python:3.10 image.

I have temporarily added a github workflow to build the image but not push it to verify that building the image is working on the github runner.