### PR TITLE
Modify service additions/replacements

### DIFF
--- a/root_orchestrator/system-manager-python/blueprints/services_blueprints.py
+++ b/root_orchestrator/system-manager-python/blueprints/services_blueprints.py
@@ -79,13 +79,12 @@ class ServiceController(MethodView):
         """
         try:
             username = get_jwt_auth_identity()
-            job = (request.get_json()["applications"][0])["microservices"][0]
-            if "_id" in job:
-                del job["_id"]
-            result, status = service_management.update_service(username, job, serviceid)
+            data = request.get_json()
+            replace = request.args.get("replace")
+            job, status = service_management.update_service(username, data, serviceid, replace)
             if status != 200:
-                abort(status, result)
-            return {}
+                abort(status, job)
+            return json_util.dumps(job)
         except ConnectionError as e:
             abort(404, {"message": e})
 


### PR DESCRIPTION
Based on the discussion @melkodary & I had during the maintainer's meeting on the 20.03.2024

# Short
Enabling the possibility to add/append/replace services to already existing applications.

# Proposal
See the code changes in this MR as an initial proposal. My changes only modify the PUT method, i.e. the use case where you want to replace an already existing service with another one.
I wanted to support any legacy code so I added a new optional query param that can be set via `?replace=true`. If a service needs to be replaced the old service needs to be properly removed and the new one properly added. Just using the legacy replace code does not work because the DB entity will be an invalid hybrid. Here is an example:
![image](https://github.com/oakestra/oakestra/assets/65814168/9097db7f-2ff2-499a-a06b-80700d83b7a5)

A few issues there are when it comes to adding/changing services of an app:
- There is no dedicated methods for this yet (AFAIK)
- The provided change object needs to be a proper SLA object, which usually needs to be fabricated specifically beforehand. I.e. not simply fetching the already existing DB entry via the API, adjusting it and pushing it back, this does not work.
- The required SLA object requires the app part of the SLA too otherwise the SLA parser will throw an error, i.e. it is not possible to provide a simple SLA object with just the new service in it.
Note following example I tried out: When you have an app with 3 services running and you want to add/replace one of those services you can do this: Create a new SLA with the wanted new service, wrap it in the app (SLA properties) you want (app ID, name should be sufficient) - without the other services, etc, so rather light weight! - you can send this and the app will be properly updated as expected - i.e. this is a current workaround - not ideal but it works without any SLA schema changes, etc.

# Ratio
This is important because there are times where you would like to replace a service with another or simply append a new service dynamically. This is not trivially possible right now.

# Impact
- system-manager
- maybe the SLA schema

# Development time
Depends on the degree of refactoring. If using what is already there (a more "hacky" approach) this should be possible in a few hours. If a proper refactoring is performed, including SLA changes, etc. This can take one to a couple of days I assume.

# Status
@melkodary wanted to take a look at this, and I thought instead of just opening a ticket I could already share my workaround for brain fodder.
The changes you see here work fine for me to fulfill my use case of replacing a service in an app dynamically.
The (unit) tests still need to be adjusted.
I am open to collaborate on this.