### PR TITLE
341 proper transparent versioning for nodeengine netmanager

### DIFF
--- a/.github/workflows/node_engine_artifacts.yml
+++ b/.github/workflows/node_engine_artifacts.yml
@@ -25,7 +25,7 @@ jobs:
         goversion: "https://go.dev/dl/go1.19.1.linux-amd64.tar.gz"
         project_path: "./go_node_engine"
         binary_name: "NodeEngine"
-        ldflags: -X "go_node_engine/cmd.Version=${{ steps.meta.outputs.tags }}"
+        ldflags: -X "go_node_engine/cmd.Version=${{ github.ref_name }}"
         release_tag: ${{ steps.meta.outputs.tags }}
         asset_name: NodeEngine_${{ matrix.goarch }}
         extra_files: go_node_engine/build/install.sh go_node_engine/build/configure-gpu.sh

--- a/.github/workflows/node_engine_artifacts.yml
+++ b/.github/workflows/node_engine_artifacts.yml
@@ -25,6 +25,7 @@ jobs:
         goversion: "https://go.dev/dl/go1.19.1.linux-amd64.tar.gz"
         project_path: "./go_node_engine"
         binary_name: "NodeEngine"
+        ldflags: -X "go_node_engine/cmd.Version=${{ steps.meta.outputs.tags }}"
         release_tag: ${{ steps.meta.outputs.tags }}
         asset_name: NodeEngine_${{ matrix.goarch }}
         extra_files: go_node_engine/build/install.sh go_node_engine/build/configure-gpu.sh

--- a/README.md
+++ b/README.md
@@ -78,7 +78,7 @@ sudo NetManager -p 6000
 
 On a different shell, start the NodeEngine with the -6000 paramenter to connect to the NetManager. 
 ```
-sudo NodeEngine -n 6000 -p 10100 -a <Cluster Orchestrator IP Address>
+sudo NodeEngine -a <Cluster Orchestrator IP Address>
 ```
 
 If you see the NodeEngine reporting metrics to the Cluster...

--- a/README.md
+++ b/README.md
@@ -256,7 +256,7 @@ cd go_node_engine/build
 Then configure the NetManager and perform the startup as usual. 
 
 N.b. each worker node can now be configured to work with a different cluster.  
-N.b. you can disable the Overlay Newtork (and therefore avoid using the NetManager using the `-n -1` flag at NodeEngine startup. 
+N.b. you can disable the Overlay Newtork (and therefore avoid using the NetManager) using the `-n -1` flag at NodeEngine startup. 
 
 
 # 🎼 Deployment descriptor

--- a/README.md
+++ b/README.md
@@ -256,8 +256,8 @@ cd go_node_engine/build
 Then configure the NetManager and perform the startup as usual. 
 
 N.b. each worker node can now be configured to work with a different cluster.  
+N.b. you can disable the Overlay Newtork (and therefore avoid using the NetManager using the `-n -1` flag at NodeEngine startup. 
 
-Alternatively you can install the latest stable binaeries
 
 # 🎼 Deployment descriptor
 <a name="🎼-deployment-descriptor"></a>

--- a/go_node_engine/NodeEngine.go
+++ b/go_node_engine/NodeEngine.go
@@ -1,82 +1,9 @@
 package main
 
 import (
-	"flag"
-	"go_node_engine/jobs"
-	"go_node_engine/logger"
-	"go_node_engine/model"
-	"go_node_engine/mqtt"
-	"go_node_engine/requests"
-	"go_node_engine/virtualization"
-	"os"
-	"os/signal"
-	"syscall"
-	"time"
+	"go_node_engine/cmd"
 )
 
-var clusterAddress = flag.String("a", "localhost", "Address of the cluster orchestrator without port")
-var clusterPort = flag.String("p", "10000", "Port of the cluster orchestrator")
-var overlayNetwork = flag.Int("n", -1, "Port of the NetManager component, if any. This enables the overlay network across nodes")
-var UnikernelSupport = flag.Bool("u", false, "Set to enable Unikernel support")
-var LogDirectory = flag.String("logs", "/tmp", "Directory for application's logs")
-
-const MONITORING_CYCLE = time.Second * 2
-
 func main() {
-	flag.Parse()
-
-	//set log directory
-	model.GetNodeInfo().SetLogDirectory(*LogDirectory)
-
-	//connect to container runtime
-	runtime := virtualization.GetContainerdClient()
-	defer runtime.StopContainerdClient()
-
-	if *UnikernelSupport {
-		unikernelRuntime := virtualization.GetUnikernelRuntime()
-		defer unikernelRuntime.StopUnikernelRuntime()
-	}
-	//hadshake with the cluster orchestrator to get mqtt port and node id
-	handshakeResult := clusterHandshake()
-
-	//enable overlay network if required
-	if *overlayNetwork > 0 {
-		model.EnableOverlay(*overlayNetwork)
-		err := requests.RegisterSelfToNetworkComponent()
-		if err != nil {
-			logger.ErrorLogger().Fatalf("Unable to register to NetManager: %v", err)
-		}
-	}
-
-	//binding the node MQTT client
-	mqtt.InitMqtt(handshakeResult.NodeId, *clusterAddress, handshakeResult.MqttPort)
-
-	//starting node status background job.
-	jobs.NodeStatusUpdater(MONITORING_CYCLE, mqtt.ReportNodeInformation)
-	//starting container resources background monitor.
-	jobs.StartServicesMonitoring(MONITORING_CYCLE, mqtt.ReportServiceResources)
-
-	// catch SIGETRM or SIGINTERRUPT
-	termination := make(chan os.Signal, 1)
-	signal.Notify(termination, syscall.SIGTERM, syscall.SIGINT, syscall.SIGKILL)
-	select {
-	case ossignal := <-termination:
-		logger.InfoLogger().Printf("Terminating the NodeEngine, signal:%v", ossignal)
-	}
-}
-
-func clusterHandshake() requests.HandshakeAnswer {
-	logger.InfoLogger().Printf("INIT: Starting handshake with cluster orchestrator %s:%s", *clusterAddress, *clusterPort)
-	node := model.GetNodeInfo()
-	logger.InfoLogger().Printf("Node Statistics: \n__________________")
-	logger.InfoLogger().Printf("CPU Cores: %d", node.CpuCores)
-	logger.InfoLogger().Printf("CPU Usage: %f", node.CpuUsage)
-	logger.InfoLogger().Printf("Mem Usage: %f", node.MemoryUsed)
-	logger.InfoLogger().Printf("GPU Driver: %s", node.GpuDriver)
-	logger.InfoLogger().Printf("\n________________")
-	clusterReponse := requests.ClusterHandshake(*clusterAddress, *clusterPort)
-	logger.InfoLogger().Printf("Got cluster response with MQTT port %s and node ID %s", clusterReponse.MqttPort, clusterReponse.NodeId)
-
-	model.SetNodeId(clusterReponse.NodeId)
-	return clusterReponse
+	cmd.Execute()
 }

--- a/go_node_engine/build/build.sh
+++ b/go_node_engine/build/build.sh
@@ -1,5 +1,7 @@
+version=$(git describe --tags --abbrev=0)
+
 #arm build
-env GOOS=linux GOARCH=arm64 go build -o NodeEngine_arm-7 ../NodeEngine.go
+env GOOS=linux GOARCH=arm64 go build -ldflags="-X 'go_node_engine/cmd.Version=$version'" -o NodeEngine_arm-7 ../NodeEngine.go
 
 #amd build
-env GOOS=linux GOARCH=amd64 go build -o NodeEngine_amd64 ../NodeEngine.go
+env GOOS=linux GOARCH=amd64 go build -ldflags="-X 'go_node_engine/cmd.Version=$version'" -o NodeEngine_amd64 ../NodeEngine.go

--- a/go_node_engine/cmd/root.go
+++ b/go_node_engine/cmd/root.go
@@ -1,0 +1,106 @@
+package cmd
+
+import (
+	"go_node_engine/jobs"
+	"go_node_engine/logger"
+	"go_node_engine/model"
+	"go_node_engine/mqtt"
+	"go_node_engine/requests"
+	"go_node_engine/virtualization"
+	"os"
+	"os/signal"
+	"syscall"
+	"time"
+
+	"github.com/spf13/cobra"
+)
+
+var (
+	rootCmd = &cobra.Command{
+		Use:   "NodeEngine",
+		Short: "Start a NoderEngine",
+		Long:  `Start a New Oakestra Worker Node`,
+		RunE: func(cmd *cobra.Command, args []string) error {
+			return startNodeEngine()
+		},
+	}
+	clusterAddress   string
+	clusterPort      int
+	overlayNetwork   int
+	unikernelSupport bool
+	logDirectory     string
+)
+
+const MONITORING_CYCLE = time.Second * 2
+
+func Execute() error {
+	rootCmd.CompletionOptions.DisableDefaultCmd = true
+	return rootCmd.Execute()
+}
+
+func init() {
+	rootCmd.Flags().StringVarP(&clusterAddress, "clusterAddr", "a", "localhost", "Address of the cluster orchestrator without port")
+	rootCmd.Flags().IntVarP(&clusterPort, "clusterPort", "p", 10100, "Port of the cluster orchestrator")
+	rootCmd.Flags().IntVarP(&overlayNetwork, "netmanagerPort", "n", 6000, "Port of the NetManager component, if any. This enables the overlay network across nodes. Use -1 to disable Overlay Network Mode.")
+	rootCmd.Flags().BoolVarP(&unikernelSupport, "unikernel", "u", false, "Enable Unikernel support. [qemu/kvm required]")
+	rootCmd.Flags().StringVarP(&logDirectory, "logs", "l", "/tmp", "Directory for application's logs")
+}
+
+func startNodeEngine() error {
+	// set log directory
+	model.GetNodeInfo().SetLogDirectory(logDirectory)
+
+	// connect to container runtime
+	runtime := virtualization.GetContainerdClient()
+	defer runtime.StopContainerdClient()
+
+	if unikernelSupport {
+		unikernelRuntime := virtualization.GetUnikernelRuntime()
+		defer unikernelRuntime.StopUnikernelRuntime()
+	}
+	// hadshake with the cluster orchestrator to get mqtt port and node id
+	handshakeResult := clusterHandshake()
+
+	// enable overlay network if required
+	if overlayNetwork > 0 {
+		model.EnableOverlay(overlayNetwork)
+		err := requests.RegisterSelfToNetworkComponent()
+		if err != nil {
+			logger.ErrorLogger().Fatalf("Unable to register to NetManager: %v", err)
+		}
+	}
+
+	// binding the node MQTT client
+	mqtt.InitMqtt(handshakeResult.NodeId, clusterAddress, handshakeResult.MqttPort)
+
+	// starting node status background job.
+	jobs.NodeStatusUpdater(MONITORING_CYCLE, mqtt.ReportNodeInformation)
+	// starting container resources background monitor.
+	jobs.StartServicesMonitoring(MONITORING_CYCLE, mqtt.ReportServiceResources)
+
+	// catch SIGETRM or SIGINTERRUPT
+	termination := make(chan os.Signal, 1)
+	signal.Notify(termination, syscall.SIGTERM, syscall.SIGINT, syscall.SIGKILL)
+	select {
+	case ossignal := <-termination:
+		logger.InfoLogger().Printf("Terminating the NodeEngine, signal:%v", ossignal)
+	}
+
+	return nil
+}
+
+func clusterHandshake() requests.HandshakeAnswer {
+	logger.InfoLogger().Printf("INIT: Starting handshake with cluster orchestrator %s:%d", clusterAddress, clusterPort)
+	node := model.GetNodeInfo()
+	logger.InfoLogger().Printf("Node Statistics: \n__________________")
+	logger.InfoLogger().Printf("CPU Cores: %d", node.CpuCores)
+	logger.InfoLogger().Printf("CPU Usage: %f", node.CpuUsage)
+	logger.InfoLogger().Printf("Mem Usage: %f", node.MemoryUsed)
+	logger.InfoLogger().Printf("GPU Driver: %s", node.GpuDriver)
+	logger.InfoLogger().Printf("\n________________")
+	clusterReponse := requests.ClusterHandshake(clusterAddress, clusterPort)
+	logger.InfoLogger().Printf("Got cluster response with MQTT port %s and node ID %s", clusterReponse.MqttPort, clusterReponse.NodeId)
+
+	model.SetNodeId(clusterReponse.NodeId)
+	return clusterReponse
+}

--- a/go_node_engine/cmd/version.go
+++ b/go_node_engine/cmd/version.go
@@ -1,0 +1,21 @@
+package cmd
+
+import (
+	"fmt"
+
+	"github.com/spf13/cobra"
+)
+
+func init() {
+	rootCmd.AddCommand(versionCmd)
+}
+
+var Version = "None"
+
+var versionCmd = &cobra.Command{
+	Use:   "version",
+	Short: "Print the version number of NodeEngine",
+	Run: func(cmd *cobra.Command, args []string) {
+		fmt.Println(Version)
+	},
+}

--- a/go_node_engine/go.mod
+++ b/go_node_engine/go.mod
@@ -33,6 +33,7 @@ require (
 	github.com/google/go-cmp v0.5.9 // indirect
 	github.com/google/uuid v1.3.0 // indirect
 	github.com/gorilla/websocket v1.5.0 // indirect
+	github.com/inconshreveable/mousetrap v1.1.0 // indirect
 	github.com/klauspost/compress v1.16.0 // indirect
 	github.com/moby/locker v1.0.1 // indirect
 	github.com/moby/sys/mountinfo v0.6.2 // indirect
@@ -44,6 +45,8 @@ require (
 	github.com/opencontainers/selinux v1.11.0 // indirect
 	github.com/pkg/errors v0.9.1 // indirect
 	github.com/sirupsen/logrus v1.9.0 // indirect
+	github.com/spf13/cobra v1.8.1 // indirect
+	github.com/spf13/pflag v1.0.5 // indirect
 	github.com/tklauser/go-sysconf v0.3.10 // indirect
 	github.com/tklauser/numcpus v0.4.0 // indirect
 	github.com/yusufpapurcu/wmi v1.2.2 // indirect

--- a/go_node_engine/go.sum
+++ b/go_node_engine/go.sum
@@ -28,6 +28,7 @@ github.com/containerd/typeurl/v2 v2.1.1 h1:3Q4Pt7i8nYwy2KmQWIw2+1hTvwTE/6w9Fqctt
 github.com/containerd/typeurl/v2 v2.1.1/go.mod h1:IDp2JFvbwZ31H8dQbEIY7sDl2L3o3HZj1hsSQlywkQ0=
 github.com/coreos/go-systemd/v22 v22.3.2/go.mod h1:Y58oyj3AT4RCenI/lSvhwexgC+NSVTIJ3seZv2GcEnc=
 github.com/cpuguy83/go-md2man/v2 v2.0.0-20190314233015-f79a8a8ca69d/go.mod h1:maD7wRr/U5Z6m/iR4s+kqSMx2CaBsrgA7czyZG/E6dU=
+github.com/cpuguy83/go-md2man/v2 v2.0.4/go.mod h1:tgQtvFlXSQOSOSIRvRPT7W67SCa46tRHOmNcaadrF8o=
 github.com/cyphar/filepath-securejoin v0.2.3/go.mod h1:aPGpWjXOXUn2NCNjFvBE6aRxGGx79pTxQpKOJNYHHl4=
 github.com/davecgh/go-spew v1.1.0/go.mod h1:J7Y8YcW2NihsgmVo/mv3lAwl/skON4iLHjSsI+c5H38=
 github.com/davecgh/go-spew v1.1.1 h1:vj9j/u1bqnvCEfJOwUhtlOARqs3+rkHYY13jYWTU97c=
@@ -92,6 +93,8 @@ github.com/google/uuid v1.3.0/go.mod h1:TIyPZe4MgqvfeYDBFedMoGGpEw/LqOeaOT+nhxU+
 github.com/gorilla/websocket v1.4.2/go.mod h1:YR8l580nyteQvAITg2hZ9XVh4b55+EU/adAjf1fMHhE=
 github.com/gorilla/websocket v1.5.0 h1:PPwGk2jz7EePpoHN/+ClbZu8SPxiqlu12wZP/3sWmnc=
 github.com/gorilla/websocket v1.5.0/go.mod h1:YR8l580nyteQvAITg2hZ9XVh4b55+EU/adAjf1fMHhE=
+github.com/inconshreveable/mousetrap v1.1.0 h1:wN+x4NVGpMsO7ErUn/mUI3vEoE6Jt13X2s0bqwp9tc8=
+github.com/inconshreveable/mousetrap v1.1.0/go.mod h1:vpF70FUmC8bwa3OWnCshd2FqLfsEA9PFc4w1p2J65bw=
 github.com/kisielk/errcheck v1.5.0/go.mod h1:pFxgyoBC7bSaBwPgfKdkLd5X25qrDl4LWUI2bnpBCr8=
 github.com/kisielk/gotool v1.0.0/go.mod h1:XhKaO+MFFWcvkIS/tQcRk01m1F5IRFswLeQ+oQHNcck=
 github.com/klauspost/compress v1.16.0 h1:iULayQNOReoYUe+1qtKOqw9CwJv3aNQu8ivo7lw1HU4=
@@ -129,6 +132,7 @@ github.com/prometheus/client_model v0.0.0-20190812154241-14fe0d1b01d4/go.mod h1:
 github.com/prometheus/procfs v0.6.0/go.mod h1:cz+aTbrPOrUb4q7XlbU9ygM+/jj0fzG6c1xBZuNvfVA=
 github.com/prometheus/procfs v0.8.0 h1:ODq8ZFEaYeCaZOJlZZdJA2AbQR98dSHSM1KW/You5mo=
 github.com/russross/blackfriday/v2 v2.0.1/go.mod h1:+Rmxgy9KzJVeS9/2gXHxylqXiyQDYRxCVz55jmeOWTM=
+github.com/russross/blackfriday/v2 v2.1.0/go.mod h1:+Rmxgy9KzJVeS9/2gXHxylqXiyQDYRxCVz55jmeOWTM=
 github.com/seccomp/libseccomp-golang v0.9.2-0.20220502022130-f33da4d89646/go.mod h1:JA8cRccbGaA1s33RQf7Y1+q9gHmZX1yB/z9WDN1C6fg=
 github.com/shirou/gopsutil v3.21.11+incompatible h1:+1+c1VGhc88SSonWP6foOcLhvnKlUeu/erjjvaPEYiI=
 github.com/shirou/gopsutil v3.21.11+incompatible/go.mod h1:5b4v6he4MtMOwMlS0TUMTu2PcXUg8+E1lC7eC3UO/RA=
@@ -136,6 +140,10 @@ github.com/shurcooL/sanitized_anchor_name v1.0.0/go.mod h1:1NzhyTcUVG4SuEtjjoZeV
 github.com/sirupsen/logrus v1.8.1/go.mod h1:yWOB1SBYBC5VeMP7gHvWumXLIWorT60ONWic61uBYv0=
 github.com/sirupsen/logrus v1.9.0 h1:trlNQbNUG3OdDrDil03MCb1H2o9nJ1x4/5LYw7byDE0=
 github.com/sirupsen/logrus v1.9.0/go.mod h1:naHLuLoDiP4jHNo9R0sCBMtWGeIprob74mVsIT4qYEQ=
+github.com/spf13/cobra v1.8.1 h1:e5/vxKd/rZsfSJMUX1agtjeTDf+qv1/JdBF8gg5k9ZM=
+github.com/spf13/cobra v1.8.1/go.mod h1:wHxEcudfqmLYa8iTfL+OuZPbBZkmvliBWKIezN3kD9Y=
+github.com/spf13/pflag v1.0.5 h1:iy+VFUOCP1a+8yFto/drg2CJ5u0yRoB7fZw3DKv/JXA=
+github.com/spf13/pflag v1.0.5/go.mod h1:McXfInJRrz4CZXVZOBLb0bTZqETkiAhM9Iw0y3An2Bg=
 github.com/stretchr/objx v0.1.0/go.mod h1:HFkY916IF+rwdDfMAkV7OtwuqBVzrE8GR6GFx+wExME=
 github.com/stretchr/objx v0.4.0/go.mod h1:YvHI0jy2hoMjB+UWwv71VJQ9isScKT/TqJzVSSt89Yw=
 github.com/stretchr/objx v0.5.0/go.mod h1:Yh+to48EsGEfYuaHDzXPcE3xhTkx73EhmCGUpEOglKo=

--- a/go_node_engine/requests/ClusterManagerRequests.go
+++ b/go_node_engine/requests/ClusterManagerRequests.go
@@ -15,13 +15,13 @@ type HandshakeAnswer struct {
 	NodeId   string `json:"id"`
 }
 
-func ClusterHandshake(address string, port string) HandshakeAnswer {
+func ClusterHandshake(address string, port int) HandshakeAnswer {
 	data, err := json.Marshal(model.GetNodeInfo())
 	if err != nil {
 		logger.ErrorLogger().Fatalf("Handshake failed, json encoding problem, %v", err)
 	}
 	jsonbody := bytes.NewBuffer(data)
-	resp, err := http.Post(fmt.Sprintf("http://%s:%s/api/node/register", address, port), "application/json", jsonbody)
+	resp, err := http.Post(fmt.Sprintf("http://%s:%d/api/node/register", address, port), "application/json", jsonbody)
 	if err != nil {
 		logger.ErrorLogger().Fatalf("Handshake failed, %v", err)
 	}


### PR DESCRIPTION
fixes #341

The PR introduces Cobra command line package to manage versioning and startup flags. 

Package version is generated automatically by replacing default version using ldflags at build time. 
The version can be checked using `NodeEngine version`

<img width="288" alt="Screenshot 2024-07-03 at 15 10 11" src="https://github.com/oakestra/oakestra/assets/25887329/5daa5cee-d4fa-44c3-9120-7e572569076a">

The rest of the flags remain unchanged but with up-to-date defaults.
<img width="1191" alt="Screenshot 2024-07-03 at 15 10 36" src="https://github.com/oakestra/oakestra/assets/25887329/ac7ec2cb-4f05-43b2-a338-6b9698f51f5b">

E.g., instead of using every time `NodeEngine -p 6000 -n 6000 -a <cluster IP>` one can simply run `NodeEngine -a <cluster IP>`