### PR TITLE
Add NodeEngine FLOps Addon Support

### DIFF
--- a/go_node_engine/addons/flops/FLOps.go
+++ b/go_node_engine/addons/flops/FLOps.go
@@ -1,0 +1,54 @@
+package flops
+
+import (
+	"go_node_engine/logger"
+	"os/exec"
+	"strings"
+)
+
+func HandleFLOpsDataManager() {
+	ml_data_server_image := "ghcr.io/oakestra/addon-flops/ml-data-server:latest"
+	container_name := "ml_data_server"
+
+	cmd := exec.Command("docker", "ps", "-a", "--format", "{{.Names}}")
+	output, err := cmd.Output()
+	if err != nil {
+		logger.ErrorLogger().Fatalln("Error:", err)
+		return
+	}
+
+	var containerExists bool
+	lines := strings.Split(string(output), "\n")
+	for _, line := range lines {
+		if line == "" {
+			continue
+		} // Skip empty lines
+		if line == container_name {
+			containerExists = true
+			break
+		}
+	}
+
+	if !containerExists {
+		cmd := exec.Command("docker", "pull", ml_data_server_image)
+		err := cmd.Run()
+
+		if err != nil {
+			logger.ErrorLogger().Fatalf("Error pulling FLOps Data Manager image: %v\n", err)
+			return
+		}
+
+		cmd = exec.Command("docker", "run", "--rm", "-d", "-p", "11027:11027", "-v", "ml_data_server_volume:/ml_data_server_volume", "--name=ml_data_server", ml_data_server_image)
+		err = cmd.Run()
+
+		if err != nil {
+			logger.ErrorLogger().Fatalf("Error running container: %v\n", err)
+			return
+		}
+
+	} else {
+		logger.InfoLogger().Printf("Container %q already exists.", container_name)
+	}
+
+	logger.InfoLogger().Printf("FLOps Data Manager container started successfully.")
+}

--- a/go_node_engine/model/Node.go
+++ b/go_node_engine/model/Node.go
@@ -31,9 +31,8 @@ const (
 type AddonType string
 
 const (
-// Example Addon:
-//
-//	FLOPS AddonType = "FLOps"
+	IMAGE_BUILDER AddonType = "image-builder"
+	FLOPS_LEARNER AddonType = "FLOps-learner"
 )
 
 // Node is the struct that describes the node


### PR DESCRIPTION
## Context
This PR is part of the migration efforts for the main OAK repo changes I performed to get the FLOps Addon working.

This PR adds the FLOps Addon support to the Node Engine.

This entails:
- A new flag "--flops-learner" that can be provided while starting the NodeEngine to enable support for the ML Data Server.
 (The ML Data Server is a docker sidecar that gets started automatically once the node engine starts. It serves an [Apache Flight Server](https://arrow.apache.org/docs/format/Flight.html) so that e.g. (Embedded/Edge) Devices can send ML data to it for storage and that deployed FLOps Oakestra Services can fetch it from the worker node to use for FL training.
 
![image](https://github.com/oakestra/oakestra/assets/65814168/8c1209b5-d746-44f5-8ad2-877af64c0521)
![image](https://github.com/oakestra/oakestra/assets/65814168/238ea46e-7db6-4251-9b0e-19c465c329c9)


It is up for debate if this is the preferred solution to get this optional Addon going.
For now, this is a tested and working solution. If we want to make this more dynamic via the work of @melkodary we can use this PR to discuss that. IMO we can merge this and adapt it if need be later on.
