### PR TITLE
[FIX] Disable SuperLinter `MULTI_STATUS` flag

### DIFF
--- a/.github/workflows/super-linter.yml
+++ b/.github/workflows/super-linter.yml
@@ -25,7 +25,7 @@
           - name: Super-linter
             uses: super-linter/super-linter/slim@v6.5.0 
             env:
-              MULTI_STATUS: true
+              MULTI_STATUS: false
               LOG_LEVEL: INFO
               IGNORE_GITIGNORED_FILES: true
               IGNORE_GENERATED_FILES: true


### PR DESCRIPTION
This change will only affect status report detailed logs, compress them from multiple action section to a single section; still the action log for each configured linter is accessible under *Details*. The flag setted to `true` require `$GITHUB_TOKEN`, causing SuperLinter execution issues as new contributor does not have read access to repository secret.
