### PR TITLE
Addons fix

### DIFF
--- a/addons_engine/addons-manager/Dockerfile
+++ b/addons_engine/addons-manager/Dockerfile
@@ -1,11 +1,11 @@
 FROM python:3.8.5-slim-buster
 LABEL org.opencontainers.image.source https://github.com/oakestra/oakestra
 
-ADD requirements.txt /
+COPY requirements.txt /
 
-RUN pip install -r requirements.txt
+RUN pip install --no-cache-dir -r requirements.txt
 
-ADD . /
+COPY . /
 
 # TRUE for verbose logging
 ENV FLASK_ENV=development

--- a/addons_engine/addons-monitor/Dockerfile
+++ b/addons_engine/addons-monitor/Dockerfile
@@ -1,11 +1,11 @@
 FROM python:3.8.5-slim-buster
 LABEL org.opencontainers.image.source https://github.com/oakestra/oakestra
 
-ADD requirements.txt /
+COPY requirements.txt /
 
-RUN pip install -r requirements.txt
+RUN pip install --no-cache-dir -r requirements.txt
 
-ADD . /
+COPY . /
 
 # TRUE for verbose logging
 ENV FLASK_ENV=development

--- a/addons_marketplace/marketplace-manager/Dockerfile
+++ b/addons_marketplace/marketplace-manager/Dockerfile
@@ -3,11 +3,11 @@ LABEL org.opencontainers.image.source https://github.com/oakestra/oakestra
 
 WORKDIR /code
 
-ADD requirements.txt /code
+COPY requirements.txt /code
 
-RUN pip install -r requirements.txt
+RUN pip install --no-cache-dir -r requirements.txt
 
-ADD . /code
+COPY . /code
 
 ENV ADDON_MARKETPLACE_PORT=11102
 ENV ADDON_MARKETPLACE_MONGO_URL=localhost

--- a/addons_marketplace/marketplace-manager/services/marketplace_service.py
+++ b/addons_marketplace/marketplace-manager/services/marketplace_service.py
@@ -10,19 +10,30 @@ def verify_addon(addon_id, addon):
     client = docker.from_env()
     for service in addon["services"]:
         image = service.get("image")
+        image_id = None
         try:
-            logging.info(f"Getting image info: {image}")
-            client.images.get_registry_data(image)
+            # TODO validate image instead of pulling it.
+            logging.info(f"Pulling image: {image}")
+            pulled_image = client.images.pull(image)
+            image_id = pulled_image.id
+            logging.info(f"Image pulled: {pulled_image}")
 
             logging.info(f"Addon-{addon_id} verified")
             marketplace_db.update_addon(
                 addon_id, {"status": marketplace_db.StatusEnum.APPROVED.value}
             )
         except docker.errors.DockerException as e:
-            logging.warning(f"Failed to get {image} data", exc_info=e)
+            logging.warning(f"Failed to pull {image}", exc_info=e)
             marketplace_db.update_addon(
                 addon_id, {"status": marketplace_db.StatusEnum.VERIFICATION_FAILED.value}
             )
+            return
+
+        try:
+            # This is not a failure, maybe the image is used by another service
+            client.images.remove(image_id)
+        except docker.errors.DockerException as e:
+            logging.warning(f"Failed to remove image {image_id}", exc_info=e)
 
 
 def register_addon(addon):


### PR DESCRIPTION
**PR**:
- Follows the linting conventions in dockerfile: 
    - using `copy` instead of `add`
    - using `--no-cache-dir` when using pip install
- Marketplace pulls the image instead of getting its data. Although fetching the data is more efficient, it only works with images hosted at docker. To include installing images hosted anywhere, we pull for the time being until we implement an efficient solution such as validating the oci image instead.