### PR TITLE
Use Maintained Compose Files

### DIFF
--- a/cluster_orchestrator/override-images-only.yaml
+++ b/cluster_orchestrator/override-images-only.yaml
@@ -1,0 +1,27 @@
+services:
+  mqtt:
+    image: eclipse-mosquitto:2.0
+
+  mongo_cluster:
+    image: mongo:3.6
+
+  cluster_service_manager:
+    image: ghcr.io/oakestra/oakestra-net/cluster-service-manager:latest
+
+  cluster_manager:
+    image: ghcr.io/oakestra/oakestra-net/cluster-manager:latest
+
+  cluster_scheduler:
+    image: ghcr.io/oakestra/oakestra-net/cluster-scheduler:latest
+
+  cluster_redis:
+    image: redis
+
+  prometheus:
+    image: prom/prometheus
+
+  cluster_grafana:
+    image: grafana/grafana
+
+  cluster_loki:
+    image: grafana/loki:2.9.2

--- a/root_orchestrator/override-images-only.yml
+++ b/root_orchestrator/override-images-only.yml
@@ -1,0 +1,31 @@
+services:
+  system_manager:
+    image: ghcr.io/oakestra/oakestra/root-system-manager:latest
+
+  mongo_root:
+    image: mongo:3.6
+
+  mongo_rootnet:
+    image: mongo:3.6
+
+  root_service_manager:
+    image: ghcr.io/oakestra/oakestra-net/root-service-manager:latest
+
+  redis:
+    image: redis
+
+  grafana:
+    image: grafana/grafana
+
+  loki:
+    image: grafana/loki:2.9.2
+
+  promtail:
+    image: grafana/promtail:2.9.2
+    
+  cloud_scheduler:
+    image: ghcr.io/oakestra/oakestra/cloud-scheduler:latest
+    
+  resource_abstractor:
+    image: ghcr.io/oakestra/oakestra/root-resource-abstractor:latest
+    

--- a/scripts/StartOakestraCluster.sh
+++ b/scripts/StartOakestraCluster.sh
@@ -112,10 +112,10 @@ if [ -z "$SYSTEM_MANAGER_URL" ]; then
     exit 1
 fi
 
-rm -rf cluster_orchestrator 2> /dev/null
-mkdir cluster_orchestrator 2> /dev/null
+rm -rf ~/oakestra/cluster_orchestrator 2> /dev/null
+mkdir -p ~/oakestra/cluster_orchestrator 2> /dev/null
 
-cd cluster_orchestrator 2> /dev/null
+cd ~/oakestra/cluster_orchestrator 2> /dev/null
 
 curl -sfL https://raw.githubusercontent.com/oakestra/oakestra/$OAKESTRA_BRANCH/scripts/utils/downloadConfigFiles.sh > downloadConfigFiles.sh
 curl -sfL https://raw.githubusercontent.com/oakestra/oakestra/$OAKESTRA_BRANCH/cluster_orchestrator/docker-compose.yml > cluster-orchestrator.yml
@@ -144,7 +144,7 @@ fi
 
 if sudo docker ps -a | grep oakestra/cluster >/dev/null 2>&1; then
   echo 🚨 Oakestra cluster containers are already running. Please stop them before starting another cluster on this machine.
-  echo 🪫 You can turn off the current cluster using: \$ docker compose -f ~/oakestra/cluster-orchestrator.yml down
+  echo 🪫 You can turn off the current cluster using: \$ docker compose -f ~/oakestra/cluster_orchestrator/cluster-orchestrator.yml down
   exit 1
 fi
 
@@ -160,4 +160,4 @@ echo 🖥️ Oakestra dashboard available at http://$SYSTEM_MANAGER_URL
 echo 📊 Root Grafana dashboard available at http://$SYSTEM_MANAGER_URL:3000
 echo 📊 Cluster Grafana dashboard available at http://<CLUSTER_IP>:3001
 echo 📈 You can access the APIs at http://$SYSTEM_MANAGER_URL:10000/api/docs
-echo 🪫 You can turn off the cluster using: \$ docker compose -f cluster_orchestrator/cluster-orchestrator.yml down
+echo 🪫 You can turn off the cluster using: \$ docker compose -f ~/oakestra/cluster_orchestrator/cluster-orchestrator.yml down

--- a/scripts/StartOakestraCluster.sh
+++ b/scripts/StartOakestraCluster.sh
@@ -119,6 +119,7 @@ cd ~/oakestra/cluster_orchestrator 2> /dev/null
 
 curl -sfL https://raw.githubusercontent.com/oakestra/oakestra/$OAKESTRA_BRANCH/scripts/utils/downloadConfigFiles.sh > downloadConfigFiles.sh
 curl -sfL https://raw.githubusercontent.com/oakestra/oakestra/$OAKESTRA_BRANCH/cluster_orchestrator/docker-compose.yml > cluster-orchestrator.yml
+curl -sfL https://raw.githubusercontent.com/oakestra/oakestra/$OAKESTRA_BRANCH/cluster_orchestrator/override-images-only.yml> override-cluster-images-only.yml
 
 chmod +x downloadConfigFiles.sh
 ./downloadConfigFiles.sh cluster_orchestrator $OAKESTRA_BRANCH
@@ -148,7 +149,7 @@ if sudo docker ps -a | grep oakestra/cluster >/dev/null 2>&1; then
   exit 1
 fi
 
-command_exec="sudo -E docker compose -f cluster-orchestrator.yml ${OAK_OVERRIDES}up --pull=always -d"
+command_exec="sudo -E docker compose -f cluster-orchestrator.yml -f override-cluster-images-only.yml ${OAK_OVERRIDES}up --pull=always -d"
 echo executing "$command_exec"
 
 eval "$command_exec"

--- a/scripts/StartOakestraCluster.sh
+++ b/scripts/StartOakestraCluster.sh
@@ -112,13 +112,13 @@ if [ -z "$SYSTEM_MANAGER_URL" ]; then
     exit 1
 fi
 
-rm -rf ~/oakestra 2> /dev/null
-mkdir ~/oakestra 2> /dev/null
+rm -rf cluster_orchestrator 2> /dev/null
+mkdir cluster_orchestrator 2> /dev/null
 
-cd ~/oakestra 2> /dev/null
+cd cluster_orchestrator 2> /dev/null
 
 curl -sfL https://raw.githubusercontent.com/oakestra/oakestra/$OAKESTRA_BRANCH/scripts/utils/downloadConfigFiles.sh > downloadConfigFiles.sh
-curl -sfL https://raw.githubusercontent.com/oakestra/oakestra/$OAKESTRA_BRANCH/run-a-cluster/cluster-orchestrator.yml > cluster-orchestrator.yml
+curl -sfL https://raw.githubusercontent.com/oakestra/oakestra/$OAKESTRA_BRANCH/cluster_orchestrator/docker-compose.yml > cluster-orchestrator.yml
 
 chmod +x downloadConfigFiles.sh
 ./downloadConfigFiles.sh cluster_orchestrator $OAKESTRA_BRANCH
@@ -160,4 +160,4 @@ echo 🖥️ Oakestra dashboard available at http://$SYSTEM_MANAGER_URL
 echo 📊 Root Grafana dashboard available at http://$SYSTEM_MANAGER_URL:3000
 echo 📊 Cluster Grafana dashboard available at http://<CLUSTER_IP>:3001
 echo 📈 You can access the APIs at http://$SYSTEM_MANAGER_URL:10000/api/docs
-echo 🪫 You can turn off the cluster using: \$ docker compose -f ~/oakestra/cluster-orchestrator.yml down
+echo 🪫 You can turn off the cluster using: \$ docker compose -f cluster_orchestrator/cluster-orchestrator.yml down

--- a/scripts/StartOakestraRoot.sh
+++ b/scripts/StartOakestraRoot.sh
@@ -35,9 +35,8 @@ if [ -z "$SYSTEM_MANAGER_URL" ]; then
     echo Default node IP: $SYSTEM_MANAGER_URL
 fi
 
-mkdir root_orchestrator 2> /dev/null
-
-cd root_orchestrator 2> /dev/null
+mkdir -p ~/oakestra/root_orchestrator 2> /dev/null
+cd ~/oakestra/root_orchestrator 2> /dev/null
 
 curl -sfL https://raw.githubusercontent.com/oakestra/oakestra/$OAKESTRA_BRANCH/scripts/utils/downloadConfigFiles.sh > downloadConfigFiles.sh
 curl -sfL https://raw.githubusercontent.com/oakestra/oakestra/$OAKESTRA_BRANCH/root_orchestrator/docker-compose.yml > root-orchestrator.yml
@@ -66,7 +65,7 @@ fi
 
 if sudo docker ps -a | grep oakestra/root >/dev/null 2>&1; then
   echo 🚨 Oakestra root containers are already running. Please stop them before starting the root orchestrator.
-  echo 🪫 You can turn off the current root using: \$ docker compose -f root_orchestrator/root-orchestrator.yml down
+  echo 🪫 You can turn off the current root using: \$ docker compose -f ~/oakestra/root_orchestrator/root-orchestrator.yml down
   exit 1
 fi
 
@@ -81,4 +80,4 @@ echo
 echo 🖥️ Oakestra dashboard available at http://$SYSTEM_MANAGER_URL
 echo 📊 Grafana dashboard available at http://$SYSTEM_MANAGER_URL:3000
 echo 📈 You can access the APIs at http://$SYSTEM_MANAGER_URL:10000/api/docs
-echo 🪫 You can turn off the cluster using: \$ docker compose -f root_orchestrator/root-orchestrator.yml down
+echo 🪫 You can turn off the cluster using: \$ docker compose -f ~/oakestra/root_orchestrator/root-orchestrator.yml down

--- a/scripts/StartOakestraRoot.sh
+++ b/scripts/StartOakestraRoot.sh
@@ -35,15 +35,15 @@ if [ -z "$SYSTEM_MANAGER_URL" ]; then
     echo Default node IP: $SYSTEM_MANAGER_URL
 fi
 
-mkdir ~/oakestra 2> /dev/null
+mkdir root_orchestrator 2> /dev/null
 
-cd ~/oakestra 2> /dev/null
+cd root_orchestrator 2> /dev/null
 
 curl -sfL https://raw.githubusercontent.com/oakestra/oakestra/$OAKESTRA_BRANCH/scripts/utils/downloadConfigFiles.sh > downloadConfigFiles.sh
-curl -sfL https://raw.githubusercontent.com/oakestra/oakestra/$OAKESTRA_BRANCH/run-a-cluster/root-orchestrator.yml > root-orchestrator.yml
+curl -sfL https://raw.githubusercontent.com/oakestra/oakestra/$OAKESTRA_BRANCH/root_orchestrator/docker-compose.yml > root-orchestrator.yml
 
 chmod +x downloadConfigFiles.sh
-./downloadConfigFiles.sh root_orchestrator $OAKESTRA_BRANCH
+./downloadConfigFiles.sh run-a-cluster $OAKESTRA_BRANCH
 
 #If additional override files provided, download them
 OAK_OVERRIDES=''
@@ -66,7 +66,7 @@ fi
 
 if sudo docker ps -a | grep oakestra/root >/dev/null 2>&1; then
   echo 🚨 Oakestra root containers are already running. Please stop them before starting the root orchestrator.
-  echo 🪫 You can turn off the current root using: \$ docker compose -f ~/oakestra/root-orchestrator.yml down
+  echo 🪫 You can turn off the current root using: \$ docker compose -f root_orchestrator/root-orchestrator.yml down
   exit 1
 fi
 
@@ -81,4 +81,4 @@ echo
 echo 🖥️ Oakestra dashboard available at http://$SYSTEM_MANAGER_URL
 echo 📊 Grafana dashboard available at http://$SYSTEM_MANAGER_URL:3000
 echo 📈 You can access the APIs at http://$SYSTEM_MANAGER_URL:10000/api/docs
-echo 🪫 You can turn off the cluster using: \$ docker compose -f ~/oakestra/root-orchestrator.yml down
+echo 🪫 You can turn off the cluster using: \$ docker compose -f root_orchestrator/root-orchestrator.yml down

--- a/scripts/StartOakestraRoot.sh
+++ b/scripts/StartOakestraRoot.sh
@@ -40,6 +40,7 @@ cd ~/oakestra/root_orchestrator 2> /dev/null
 
 curl -sfL https://raw.githubusercontent.com/oakestra/oakestra/$OAKESTRA_BRANCH/scripts/utils/downloadConfigFiles.sh > downloadConfigFiles.sh
 curl -sfL https://raw.githubusercontent.com/oakestra/oakestra/$OAKESTRA_BRANCH/root_orchestrator/docker-compose.yml > root-orchestrator.yml
+curl -sfL https://raw.githubusercontent.com/oakestra/oakestra/$OAKESTRA_BRANCH/root_orchestrator/override-images-only.yml > override-root-images-only.yml
 
 chmod +x downloadConfigFiles.sh
 ./downloadConfigFiles.sh run-a-cluster $OAKESTRA_BRANCH
@@ -69,7 +70,7 @@ if sudo docker ps -a | grep oakestra/root >/dev/null 2>&1; then
   exit 1
 fi
 
-command_exec="sudo -E docker compose -f root-orchestrator.yml ${OAK_OVERRIDES}up --pull=always -d"
+command_exec="sudo -E docker compose -f root-orchestrator.yml -f override-root-images-only.yml ${OAK_OVERRIDES}up --pull=always -d"
 echo executing "$command_exec"
 
 eval "$command_exec"


### PR DESCRIPTION
The standalone build scripts now use the docker compose files that are used when manually building the Oakestra components. This means there is only one set of compose files that have to be maintained.
When building the warning `pull access denied for ...` is printed for multiple containers, however as far as I can tell everything still works.
Additionally instead of creating a directory in the home directory, it is placed in a new directory wherever the script is executed. I was confused by this when I used these scripts the first time myself.