### PR TITLE
Make Worker Install Script OS Agnostic

### DIFF
--- a/scripts/InstallOakestraWorker.sh
+++ b/scripts/InstallOakestraWorker.sh
@@ -8,25 +8,40 @@ else
     fi
 fi
 
+ARCH=$(uname -m)
+
+if [ "$ARCH" = "x86_64" ]; then
+    ARCH=amd64
+else
+    if [ "$ARCH" = "aarch64" ]; then
+        ARCH=arm64
+    fi
+fi
+if [ "$ARCH" != "amd64" ] && [ "$ARCH" != "arm64" ]; then
+    echo "Error: Unsupported architecture '${ARCH}'"
+    exit 1
+fi
+
+
 echo Installing Oakestra Node Engine and Net Manager version $OAKESTRA_VERSION
 
-rm NodeEngine_$(dpkg --print-architecture).tar.gz 2> /dev/null
-rm NetManager_$(dpkg --print-architecture).tar.gz 2> /dev/null
+rm NodeEngine_$ARCH.tar.gz 2> /dev/null
+rm NetManager_$ARCH.tar.gz 2> /dev/null
 
-wget -c https://github.com/oakestra/oakestra/releases/download/$OAKESTRA_VERSION/NodeEngine_$(dpkg --print-architecture).tar.gz &&
-    tar -xzf NodeEngine_$(dpkg --print-architecture).tar.gz &&
+wget -c https://github.com/oakestra/oakestra/releases/download/$OAKESTRA_VERSION/NodeEngine_$ARCH.tar.gz &&
+    tar -xzf NodeEngine_$ARCH.tar.gz &&
     chmod +x install.sh &&
-    ./install.sh $(dpkg --print-architecture)
+    ./install.sh $ARCH
 
 if [ $? -ne 0 ]; then
         echo "Error: Failed to retrieve or install the Oakestra Node Engine."
         exit 1
 fi
 
-wget -c https://github.com/oakestra/oakestra-net/releases/download/$OAKESTRA_VERSION/NetManager_$(dpkg --print-architecture).tar.gz &&
-    tar -xzf NetManager_$(dpkg --print-architecture).tar.gz &&
+wget -c https://github.com/oakestra/oakestra-net/releases/download/$OAKESTRA_VERSION/NetManager_$ARCH.tar.gz &&
+    tar -xzf NetManager_$ARCH.tar.gz &&
     chmod +x install.sh &&
-    ./install.sh $(dpkg --print-architecture)
+    ./install.sh $ARCH
 
 if [ $? -ne 0 ]; then
         echo "Error: Failed to retrieve or install the Oakestra Net Manager."


### PR DESCRIPTION
Fixes #378.

No longer uses `dpkg --print-architecture` to determine processor architecture. Is also generally more robust by checking for synonymous architecture specifiers and throwing an error if architecture is not supported.