### PR TITLE
Upgrade MongoDB Dependencies

### DIFF
--- a/cluster_orchestrator/cluster-manager/requirements.txt
+++ b/cluster_orchestrator/cluster-manager/requirements.txt
@@ -1,7 +1,7 @@
 Flask~=2.1.1
 marshmallow~=3.15.0
 paho-mqtt==1.6.1
-Flask-PyMongo
+Flask-PyMongo==2.3.0
 Flask-SocketIO==4.3.1
 eventlet==0.33.3
 requests

--- a/cluster_orchestrator/cluster-scheduler/requirements.txt
+++ b/cluster_orchestrator/cluster-scheduler/requirements.txt
@@ -1,8 +1,8 @@
 flask
-flask_pymongo
+flask_pymongo==2.3.0
 celery==4.4.2
 click
 redis
 requests
-pymongo
+pymongo==4.10.1
 git+https://github.com/oakestra/oakestra.git@develop#subdirectory=libraries/oakestra_utils_library

--- a/cluster_orchestrator/docker-compose.yml
+++ b/cluster_orchestrator/docker-compose.yml
@@ -31,7 +31,7 @@ services:
       
   # cluster-level mongoDB
   mongo_cluster:
-    image: mongo:3.6
+    image: mongo:8.0
     container_name: cluster_mongo
     hostname: cluster_mongo
     ports:
@@ -42,7 +42,7 @@ services:
 
   # cluster-level mongoDB
   mongo_clusternet:
-    image: mongo:3.6
+    image: mongo:8.0
     container_name: cluster_mongo_net
     hostname: cluster_mongo_net
     ports:

--- a/cluster_orchestrator/override-images-only.yml
+++ b/cluster_orchestrator/override-images-only.yml
@@ -4,7 +4,7 @@ services:
     pull_policy: always
 
   mongo_cluster:
-    image: mongo:3.6
+    image: mongo:8.0
     pull_policy: always
 
   cluster_service_manager:

--- a/root_orchestrator/docker-compose.yml
+++ b/root_orchestrator/docker-compose.yml
@@ -40,7 +40,7 @@ services:
 
   # MongoDB in Root Orchestrator
   mongo_root:
-    image: mongo:3.6
+    image: mongo:8.0
     container_name: mongo
     hostname: mongo
     ports:
@@ -53,7 +53,7 @@ services:
 
   # cluster-level mongoDB
   mongo_rootnet:
-    image: mongo:3.6
+    image: mongo:8.0
     container_name: mongo_net
     hostname: mongo_net
     ports:

--- a/root_orchestrator/override-images-only.yml
+++ b/root_orchestrator/override-images-only.yml
@@ -4,11 +4,11 @@ services:
     pull_policy: always
 
   mongo_root:
-    image: mongo:3.6
+    image: mongo:8.0
     pull_policy: always
 
   mongo_rootnet:
-    image: mongo:3.6
+    image: mongo:8.0
     pull_policy: always
 
   root_service_manager:

--- a/root_orchestrator/system-manager-python/requirements.txt
+++ b/root_orchestrator/system-manager-python/requirements.txt
@@ -13,7 +13,7 @@ flask_cors
 PyPi
 flask_jwt_extended
 flask_restful
-pymongo~=4.1.1
+pymongo~=4.10.1
 werkzeug==2.0.3
 MarkupSafe~=2.1.1
 flask_swagger_ui

--- a/run-a-cluster/1-DOC.yaml
+++ b/run-a-cluster/1-DOC.yaml
@@ -50,10 +50,12 @@ services:
 
   # MongoDB in Root Orchestrator
   mongo_root:
-    image: mongo:3.6
+    image: mongo:8.0
     pull_policy: always
     container_name: mongo
     hostname: mongo
+    ports:
+      - "10007:10007"
     expose:
       - "10007"
     volumes:
@@ -62,12 +64,14 @@ services:
 
   # cluster-level mongoDB
   mongo_rootnet:
-    image: mongo:3.6
+    image: mongo:8.0
     pull_policy: always
     container_name: mongo_net
     hostname: mongo_net
     labels:
       logging: "promtail"
+    ports:
+      - "10008:10008"
     expose:
       - "10008"
     volumes:
@@ -180,10 +184,12 @@ services:
 
   # cluster-level mongoDB
   mongo_cluster:
-    image: mongo:3.6
+    image: mongo:8.0
     pull_policy: always
     container_name: cluster_mongo
     hostname: cluster_mongo
+    ports:
+      - "10107:10107"
     expose:
       - "10107"
     volumes:
@@ -192,10 +198,12 @@ services:
 
   # cluster-level mongoDB
   mongo_clusternet:
-    image: mongo:3.6
+    image: mongo:8.0
     pull_policy: always
     container_name: cluster_mongo_net
     hostname: cluster_mongo_net
+    ports:
+      - "10108:10108"
     expose:
       - "10108"
     volumes:

--- a/run-a-cluster/root-orchestrator.yml
+++ b/run-a-cluster/root-orchestrator.yml
@@ -34,7 +34,7 @@ services:
 
   # MongoDB in Root Orchestrator
   mongo_root:
-    image: mongo:3.6
+    image: mongo:8.0
     container_name: mongo
     hostname: mongo
     ports:
@@ -47,7 +47,7 @@ services:
 
   # root-level mongoDB
   mongo_rootnet:
-    image: mongo:3.6
+    image: mongo:8.0
     container_name: mongo_net
     hostname: mongo_net
     ports:


### PR DESCRIPTION
# Why this MR
I like debugging our DBs by using the MongoDB Extension for VSCode - turns out our MongoDB versions are so outdated that the extension no longer supports them.

# What does this MR change?
- Upgrades MongoDB related dependencies to stable/latest versions
- Adds port mappings to the 1-DOC compose file
  - this is necessary to be able to connect to the DBs via the extension (ports are already used for the multi-cluster compose files)
  
# Sanity Checks
I have successfully created our default apps and was able to curl from one service to the other.
More advanced tests are welcome. (maybe the AWX suite?) @giobart 
I have looked a bit into possible/recommended migration steps, but one gets overwhelmed by steps that are relevant for folks who need to update an existing DB to a new version, which is not really something that applies to u - furthermore, we only use very basic MongoDB commands (via its python libs) anyways.