### PR TITLE
Fix Typo breaking cluster images overrides

### DIFF
--- a/scripts/StartOakestraCluster.sh
+++ b/scripts/StartOakestraCluster.sh
@@ -132,7 +132,7 @@ cd ~/oakestra/cluster_orchestrator 2> /dev/null
 
 curl -sfL https://raw.githubusercontent.com/oakestra/oakestra/$OAKESTRA_BRANCH/scripts/utils/downloadConfigFiles.sh > downloadConfigFiles.sh
 curl -sfL https://raw.githubusercontent.com/oakestra/oakestra/$OAKESTRA_BRANCH/cluster_orchestrator/docker-compose.yml > cluster-orchestrator.yml
-curl -sfL https://raw.githubusercontent.com/oakestra/oakestra/$OAKESTRA_BRANCH/cluster_orchestrator/override-images-only.yml> override-cluster-images-only.yml
+curl -sfL https://raw.githubusercontent.com/oakestra/oakestra/$OAKESTRA_BRANCH/cluster_orchestrator/override-images-only.yml > override-cluster-images-only.yml
 
 chmod +x downloadConfigFiles.sh
 ./downloadConfigFiles.sh cluster_orchestrator $OAKESTRA_BRANCH


### PR DESCRIPTION
### Context
I was trying out deploying the root and cluster separately with the modern/latest recommended curl scripts.
I noticed that the root worked fine but the cluster docker compose process failed due to a file it was not able to find.

![image](https://github.com/user-attachments/assets/b0583b36-2109-4ac7-ae44-5e2a70b9262a)

After looking into this I figured out that the cluster-scheduler image was not properly replaced/pulled - but it should have been because we are using the image override yaml.

There is a very simple typo that breaks this.
As a result, the override file "exists" but is empty.

![image](https://github.com/user-attachments/assets/66d36b09-350e-46c5-8953-f2e35a2fc405)

