### PR TITLE
Support https Cluster Handshake

### DIFF
--- a/go_node_engine/cmd/conf.go
+++ b/go_node_engine/cmd/conf.go
@@ -27,6 +27,7 @@ func init() {
 	setCni.AddCommand(disableNetwork)
 	setCni.AddCommand(enableManualNetwork)
 	addClusterCmd.Flags().IntVarP(&clusterPort, "clusterPort", "p", 10100, "Custom port of the cluster orchestrator")
+	addClusterCmd.Flags().BoolVarP(&clusterSSL, "clusterSSL", "s", false, "Perform cluster orchestrator handshake over HTTPS")
 	configCmd.AddCommand(setAddonCmd)
 	setAddonCmd.AddCommand(enableBuilder)
 	setAddonCmd.AddCommand(enableFlops)
@@ -175,11 +176,13 @@ func configCluster(address string) error {
 
 	clusterConf.ClusterAddress = address
 	clusterConf.ClusterPort = clusterPort
+	clusterConf.ClusterSSL = clusterSSL
 
 	return configManager.Write(clusterConf)
 }
 
 func configAddress(address string) error {
+	fmt.Println("here")
 	configManager := config.GetConfFileManager()
 	clusterConf, err := configManager.Get()
 	if err != nil {
@@ -196,6 +199,16 @@ func configPort(port int) error {
 		return err
 	}
 	clusterConf.ClusterPort = port
+	return configManager.Write(clusterConf)
+}
+
+func configSSL(encrypt bool) error {
+	configManager := config.GetConfFileManager()
+	clusterConf, err := configManager.Get()
+	if err != nil {
+		return err
+	}
+	clusterConf.ClusterSSL = encrypt
 	return configManager.Write(clusterConf)
 }
 

--- a/go_node_engine/cmd/conf.go
+++ b/go_node_engine/cmd/conf.go
@@ -182,7 +182,6 @@ func configCluster(address string) error {
 }
 
 func configAddress(address string) error {
-	fmt.Println("here")
 	configManager := config.GetConfFileManager()
 	clusterConf, err := configManager.Get()
 	if err != nil {

--- a/go_node_engine/cmd/root.go
+++ b/go_node_engine/cmd/root.go
@@ -25,6 +25,7 @@ var (
 	}
 	clusterAddress string
 	clusterPort    int
+	clusterSSL     bool
 	detatched      bool
 	// Addons
 	imageBuilder        bool
@@ -74,6 +75,14 @@ func nodeEngineDaemonManager() error {
 		}
 	}
 
+	if clusterSSL != false {
+		// set new SSL settings
+		err := configSSL(clusterSSL)
+		if err != nil {
+			return err
+		}
+	}
+
 	if certFile != "" || keyFile != "" {
 		// set Mqtt auth parameters
 		err := setMqttAuth()
@@ -89,6 +98,7 @@ func nodeEngineDaemonManager() error {
 	}
 
 	fmt.Println("NodeEngine started  🟢")
+	fmt.Println("something")
 	if !detatched {
 		return attach()
 	}

--- a/go_node_engine/cmd/root.go
+++ b/go_node_engine/cmd/root.go
@@ -76,7 +76,7 @@ func nodeEngineDaemonManager() error {
 	}
 
 	if clusterSSL != false {
-		// set new SSL settings
+		// set SSL cluster handshake
 		err := configSSL(clusterSSL)
 		if err != nil {
 			return err
@@ -98,7 +98,6 @@ func nodeEngineDaemonManager() error {
 	}
 
 	fmt.Println("NodeEngine started  🟢")
-	fmt.Println("something")
 	if !detatched {
 		return attach()
 	}

--- a/go_node_engine/config/config.go
+++ b/go_node_engine/config/config.go
@@ -14,6 +14,7 @@ var AUTO_OAK_NETWORK = "default"
 type ConfFile struct {
 	ConfVersion     string           `json:"conf_version"`
 	ClusterAddress  string           `json:"cluster_address"`
+	ClusterSSL      bool             `json:"cluster_ssl"`
 	ClusterPort     int              `json:"cluster_port"`
 	AppLogs         string           `json:"app_logs"`
 	OverlayNetwork  string           `json:"overlay_network"`
@@ -143,6 +144,7 @@ func GenDefaultConfig() ConfFile {
 		ConfVersion:    "1.0",
 		ClusterAddress: "0.0.0.0",
 		ClusterPort:    10100,
+		ClusterSSL:     false,
 		AppLogs:        DEFAULT_LOG_DIR,
 		OverlayNetwork: AUTO_OAK_NETWORK,
 		NetPort:        0,

--- a/go_node_engine/requests/ClusterManagerRequests.go
+++ b/go_node_engine/requests/ClusterManagerRequests.go
@@ -4,6 +4,7 @@ import (
 	"bytes"
 	"encoding/json"
 	"fmt"
+	"go_node_engine/config"
 	"go_node_engine/logger"
 	"go_node_engine/model"
 	"io"
@@ -23,7 +24,19 @@ func ClusterHandshake(address string, port int) HandshakeAnswer {
 		logger.ErrorLogger().Fatalf("Handshake failed, json encoding problem, %v", err)
 	}
 	jsonbody := bytes.NewBuffer(data)
-	resp, err := http.Post(fmt.Sprintf("http://%s:%d/api/node/register", address, port), "application/json", jsonbody)
+
+	cfg, err := config.GetConfFileManager().Get()
+	if err != nil {
+		logger.ErrorLogger().Fatalf("Could not get config")
+	}
+
+	var resp *http.Response
+	if cfg.ClusterSSL {
+		resp, err = http.Post(fmt.Sprintf("https://%s:%d/api/node/register", address, port), "application/json", jsonbody)
+	} else {
+		resp, err = http.Post(fmt.Sprintf("http://%s:%d/api/node/register", address, port), "application/json", jsonbody)
+	}
+
 	if err != nil {
 		logger.ErrorLogger().Fatalf("Handshake failed, %v", err)
 	}

--- a/go_node_engine/requests/ClusterManagerRequests.go
+++ b/go_node_engine/requests/ClusterManagerRequests.go
@@ -31,11 +31,11 @@ func ClusterHandshake(address string, port int) HandshakeAnswer {
 	}
 
 	var resp *http.Response
+	proto := "http"
 	if cfg.ClusterSSL {
-		resp, err = http.Post(fmt.Sprintf("https://%s:%d/api/node/register", address, port), "application/json", jsonbody)
-	} else {
-		resp, err = http.Post(fmt.Sprintf("http://%s:%d/api/node/register", address, port), "application/json", jsonbody)
-	}
+		proto = "https"
+	} 
+	resp, err = http.Post(fmt.Sprintf("%s://%s:%d/api/node/register",proto, address, port), "application/json", jsonbody)
 
 	if err != nil {
 		logger.ErrorLogger().Fatalf("Handshake failed, %v", err)

--- a/go_node_engine/requests/ClusterManagerRequests.go
+++ b/go_node_engine/requests/ClusterManagerRequests.go
@@ -34,8 +34,8 @@ func ClusterHandshake(address string, port int) HandshakeAnswer {
 	proto := "http"
 	if cfg.ClusterSSL {
 		proto = "https"
-	} 
-	resp, err = http.Post(fmt.Sprintf("%s://%s:%d/api/node/register",proto, address, port), "application/json", jsonbody)
+	}
+	resp, err = http.Post(fmt.Sprintf("%s://%s:%d/api/node/register", proto, address, port), "application/json", jsonbody)
 
 	if err != nil {
 		logger.ErrorLogger().Fatalf("Handshake failed, %v", err)


### PR DESCRIPTION
Fixes #399 

This allows the NodeEngine to perform the cluster handshake over https. This setting has to be enabled by the user and is disabled per default.
To enable:
```
sudo NodeEngine config cluster <Addess of Cluster> -s
```
To disable simply ommit the -s flag:
```
sudo NodeEngine config cluster <Addess of Cluster>
```