### PR TITLE
Added delete addon API endpoint

### DIFF
--- a/addons_marketplace/marketplace-manager/api/v1/marketplace_blueprint.py
+++ b/addons_marketplace/marketplace-manager/api/v1/marketplace_blueprint.py
@@ -34,6 +34,7 @@ class MarketPlaceAddonController(MethodView):
             abort(404, message="Addon not found")
 
         return addon
+
     @marketplaceblp.response(200, MarketplaceAddonSchema, content_type="application/json")
     def delete(self, marketplace_addon_id):
         del_res = marketplace_db.delete_addon_by_id(marketplace_addon_id)

--- a/addons_marketplace/marketplace-manager/api/v1/marketplace_blueprint.py
+++ b/addons_marketplace/marketplace-manager/api/v1/marketplace_blueprint.py
@@ -34,3 +34,10 @@ class MarketPlaceAddonController(MethodView):
             abort(404, message="Addon not found")
 
         return addon
+    @marketplaceblp.response(200, MarketplaceAddonSchema, content_type="application/json")
+    def delete(self, marketplace_addon_id):
+        del_res = marketplace_db.delete_addon_by_id(marketplace_addon_id)
+        if del_res.deleted_count == 0:
+            abort(404, message="Addon not found")
+        else:
+            return

--- a/addons_marketplace/marketplace-manager/api/v1/marketplace_blueprint.py
+++ b/addons_marketplace/marketplace-manager/api/v1/marketplace_blueprint.py
@@ -35,10 +35,8 @@ class MarketPlaceAddonController(MethodView):
 
         return addon
 
-    @marketplaceblp.response(200, MarketplaceAddonSchema, content_type="application/json")
+    @marketplaceblp.response(204)
     def delete(self, marketplace_addon_id):
         del_res = marketplace_db.delete_addon_by_id(marketplace_addon_id)
         if del_res.deleted_count == 0:
             abort(404, message="Addon not found")
-        else:
-            return

--- a/addons_marketplace/marketplace-manager/db/marketplace_db.py
+++ b/addons_marketplace/marketplace-manager/db/marketplace_db.py
@@ -35,5 +35,6 @@ def update_addon(addon_id, addon_data):
         {"_id": ObjectId(addon_id)}, {"$set": addon_data}, return_document=True
     )
 
+
 def delete_addon_by_id(addon_id):
     return db.mongo_marketplace.delete_one({"_id": ObjectId(addon_id)})

--- a/addons_marketplace/marketplace-manager/db/marketplace_db.py
+++ b/addons_marketplace/marketplace-manager/db/marketplace_db.py
@@ -34,3 +34,6 @@ def update_addon(addon_id, addon_data):
     return db.mongo_marketplace.find_one_and_update(
         {"_id": ObjectId(addon_id)}, {"$set": addon_data}, return_document=True
     )
+
+def delete_addon_by_id(addon_id):
+    return db.mongo_marketplace.delete_one({"_id": ObjectId(addon_id)})


### PR DESCRIPTION
Once an addon has been POSTed to the Addon Marketplace Api it cannot be delted again, eventually clogging the marketplace with redundant addons.
This PR adds the `/api/v1/marketplace/addons/{marketplace_addon_id}` endpoint and a mongodb function to perform the delete.