### PR TITLE
Prevent duplicate docker network addition

### DIFF
--- a/addons_engine/addons-monitor/services/monitor_service.py
+++ b/addons_engine/addons-monitor/services/monitor_service.py
@@ -169,7 +169,7 @@ class AddonsMonitor:
                 container_networks = runner_engine.get_container_networks(similar_container)
                 container_ports = runner_engine.get_container_ports(similar_container)
                 if container_networks:
-                    service.get("networks").extend(container_networks)
+                    service.get("networks").extend(x for x in container_networks if x not in service.get("networks"))
 
                 # extending the ports of the image, but don't override the configured ones
                 service["ports"] = service.get("ports", {})

--- a/addons_engine/addons-monitor/services/monitor_service.py
+++ b/addons_engine/addons-monitor/services/monitor_service.py
@@ -169,7 +169,9 @@ class AddonsMonitor:
                 container_networks = runner_engine.get_container_networks(similar_container)
                 container_ports = runner_engine.get_container_ports(similar_container)
                 if container_networks:
-                    service.get("networks").extend(x for x in container_networks if x not in service.get("networks"))
+                    service.get("networks").extend(
+                        x for x in container_networks if x not in service.get("networks")
+                    )
 
                 # extending the ports of the image, but don't override the configured ones
                 service["ports"] = service.get("ports", {})


### PR DESCRIPTION
When installing a plugin via the addons system the addons_monitor will throw
```
docker.errors.APIError: 403 Client Error for http+docker://localhost/v1.49/networks/8b3c54acfbad6df4ca2ea22083c64beb155697425e3b66db84b752d20558608b/connect: Forbidden ("endpoint with name cloud_scheduler already exists in network oakestra")
```
This is because the addons will attempt to register the plugin with the same network twice, resulting in an error in the second attempt. To prevent this duplicate networks for the service are filtered out.