### PR TITLE
Cleanup hanging containers

### DIFF
--- a/cluster_orchestrator/cluster-manager/mongodb_client.py
+++ b/cluster_orchestrator/cluster-manager/mongodb_client.py
@@ -86,12 +86,15 @@ def mongo_find_node_by_id_and_update_cpu_mem(node_id, node_payload):
     # o = mongo.db.nodes.find_one({'_id': node_id})
     # print(o)
 
+    prev_ip = mongo_nodes.db.nodes.find_one({"_id": ObjectId(node_id)}).get("current_ip_address")
+
     time_now = datetime.now()
 
     mongo_nodes.db.nodes.find_one_and_update(
         {"_id": ObjectId(node_id)},
         {
             "$set": {
+                "current_ip_address": node_payload.get("ip", 0),
                 "current_cpu_percent": node_payload.get("cpu", 0),
                 "current_cpu_cores_free": node_payload.get("free_cores", 0),
                 "current_memory_percent": node_payload.get("memory", 0),
@@ -108,6 +111,10 @@ def mongo_find_node_by_id_and_update_cpu_mem(node_id, node_payload):
         },
         upsert=True,
     )
+
+    curr_ip = mongo_nodes.db.nodes.find_one({"_id": ObjectId(node_id)}).get("current_ip_address")
+    if prev_ip != curr_ip:
+        app.logger.info("IP_CHANGE - Node with id {0} changed its IP address".format(node_id))
 
     return 1
 

--- a/cluster_orchestrator/cluster-manager/mongodb_client.py
+++ b/cluster_orchestrator/cluster-manager/mongodb_client.py
@@ -85,12 +85,9 @@ def mongo_find_node_by_id_and_update_cpu_mem(node_id, node_payload):
     app.logger.info("MONGODB - update cpu and memory of worker node {0} ...".format(node_id))
     # o = mongo.db.nodes.find_one({'_id': node_id})
     # print(o)
-
-    prev_ip = mongo_nodes.db.nodes.find_one({"_id": ObjectId(node_id)}).get("current_ip_address")
-
     time_now = datetime.now()
 
-    mongo_nodes.db.nodes.find_one_and_update(
+    prev_document = mongo_nodes.db.nodes.find_one_and_update(
         {"_id": ObjectId(node_id)},
         {
             "$set": {
@@ -112,7 +109,8 @@ def mongo_find_node_by_id_and_update_cpu_mem(node_id, node_payload):
         upsert=True,
     )
 
-    curr_ip = mongo_nodes.db.nodes.find_one({"_id": ObjectId(node_id)}).get("current_ip_address")
+    prev_ip = prev_document.get("current_ip_address")
+    curr_ip = node_payload.get("ip", 0)
     if prev_ip != curr_ip:
         app.logger.info("IP_CHANGE - Node with id {0} changed its IP address".format(node_id))
 

--- a/go_node_engine/cmd/conf.go
+++ b/go_node_engine/cmd/conf.go
@@ -19,6 +19,7 @@ func init() {
 	configCmd.AddCommand(setVirtualizationCmd)
 	configCmd.AddCommand(defaultConfigCmd)
 	configCmd.AddCommand(setCni)
+	configCmd.AddCommand(visibility)
 	configCmd.AddCommand(setAuth)
 	setAuth.Flags().StringVarP(&certFile, "certFile", "c", "", "Path to certificate for TLS support")
 	setAuth.Flags().StringVarP(&keyFile, "keyFile", "k", "", "Path to key for TLS support")
@@ -27,9 +28,8 @@ func init() {
 	setCni.AddCommand(enableNetwork)
 	setCni.AddCommand(disableNetwork)
 	setCni.AddCommand(enableManualNetwork)
-	setCni.AddCommand(explainIP)
-	setCni.AddCommand(publicIP)
-	setCni.AddCommand(privateIP)
+	visibility.AddCommand(publicIP)
+	visibility.AddCommand(privateIP)
 	addClusterCmd.Flags().IntVarP(&clusterPort, "clusterPort", "p", 10100, "Custom port of the cluster orchestrator")
 	configCmd.AddCommand(setAddonCmd)
 	setAddonCmd.AddCommand(enableBuilder)
@@ -123,7 +123,7 @@ var (
 
 	// --- NETWORKING
 	setCni = &cobra.Command{
-		Use:   "network [auto/custom/off] [public/private]",
+		Use:   "network [auto/custom/off]",
 		Short: "Configure networking support",
 	}
 	explainNetManager = &cobra.Command{
@@ -150,13 +150,15 @@ var (
 	}
 	disableNetwork = &cobra.Command{
 		Use:   "off",
-		Short: "Disable overlay network support\n",
+		Short: "Disable overlay network support",
 		RunE: func(cmd *cobra.Command, args []string) error {
 			return setNetwork("")
 		},
 	}
-	explainIP = &cobra.Command{
-		Use:   "[public/private]",
+
+	// --- VISIBILITY
+	visibility = &cobra.Command{
+		Use:   "visibility [public/private]",
 		Short: "Use public or private IP",
 	}
 	publicIP = &cobra.Command{

--- a/go_node_engine/cmd/conf.go
+++ b/go_node_engine/cmd/conf.go
@@ -26,6 +26,8 @@ func init() {
 	setCni.AddCommand(enableNetwork)
 	setCni.AddCommand(disableNetwork)
 	setCni.AddCommand(enableManualNetwork)
+	setCni.AddCommand(publicIP)
+	setCni.AddCommand(privateIP)
 	addClusterCmd.Flags().IntVarP(&clusterPort, "clusterPort", "p", 10100, "Custom port of the cluster orchestrator")
 	configCmd.AddCommand(setAddonCmd)
 	setAddonCmd.AddCommand(enableBuilder)
@@ -131,7 +133,7 @@ var (
 	}
 	enableManualNetwork = &cobra.Command{
 		Use:   "manual [socket path]",
-		Short: "Manually pre-configured overlay network client. Default socket: /etc/netmanager/netmanager.sock (usefull for debug and testing of custom overlay networks)",
+		Short: "Manually pre-configured overlay network client. Default socket: /etc/netmanager/netmanager.sock (useful for debug and testing of custom overlay networks)",
 		RunE: func(cmd *cobra.Command, args []string) error {
 			socketPath := "custom:/etc/netmanager/netmanager.sock"
 			if len(args) == 1 {
@@ -145,6 +147,20 @@ var (
 		Short: "Disable overlay network support",
 		RunE: func(cmd *cobra.Command, args []string) error {
 			return setNetwork("")
+		},
+	}
+	publicIP = &cobra.Command{
+		Use:   "public",
+		Short: "Allow networking over the public IP address",
+		RunE: func(cmd *cobra.Command, args []string) error {
+			return setPublicIp(true)
+		},
+	}
+	privateIP = &cobra.Command{
+		Use:   "private",
+		Short: "Disallow networking over the public IP address",
+		RunE: func(cmd *cobra.Command, args []string) error {
+			return setPublicIp(false)
 		},
 	}
 
@@ -383,6 +399,17 @@ func setNetwork(cniName string) error {
 	}
 
 	clusterConf.OverlayNetwork = cniName
+
+	return configManager.Write(clusterConf)
+}
+
+func setPublicIp(public bool) error {
+	configManager := config.GetConfFileManager()
+	clusterConf, err := configManager.Get()
+	if err != nil {
+		return err
+	}
+	clusterConf.PublicIp = public
 
 	return configManager.Write(clusterConf)
 }

--- a/go_node_engine/cmd/conf.go
+++ b/go_node_engine/cmd/conf.go
@@ -23,9 +23,11 @@ func init() {
 	setAuth.Flags().StringVarP(&certFile, "certFile", "c", "", "Path to certificate for TLS support")
 	setAuth.Flags().StringVarP(&keyFile, "keyFile", "k", "", "Path to key for TLS support")
 	setVirtualizationCmd.AddCommand(enableUnikernel)
+	setCni.AddCommand(explainNetManager)
 	setCni.AddCommand(enableNetwork)
 	setCni.AddCommand(disableNetwork)
 	setCni.AddCommand(enableManualNetwork)
+	setCni.AddCommand(explainIP)
 	setCni.AddCommand(publicIP)
 	setCni.AddCommand(privateIP)
 	addClusterCmd.Flags().IntVarP(&clusterPort, "clusterPort", "p", 10100, "Custom port of the cluster orchestrator")
@@ -121,8 +123,12 @@ var (
 
 	// --- NETWORKING
 	setCni = &cobra.Command{
-		Use:   "network [auto/custom/off]",
-		Short: "Enable/Disable networking support",
+		Use:   "network [auto/custom/off] [public/private]",
+		Short: "Configure networking support",
+	}
+	explainNetManager = &cobra.Command{
+		Use:   "[auto/custom/off]",
+		Short: "Enable/disable automatic networking support",
 	}
 	enableNetwork = &cobra.Command{
 		Use:   "auto",
@@ -144,10 +150,14 @@ var (
 	}
 	disableNetwork = &cobra.Command{
 		Use:   "off",
-		Short: "Disable overlay network support",
+		Short: "Disable overlay network support\n",
 		RunE: func(cmd *cobra.Command, args []string) error {
 			return setNetwork("")
 		},
+	}
+	explainIP = &cobra.Command{
+		Use:   "[public/private]",
+		Short: "Use public or private IP",
 	}
 	publicIP = &cobra.Command{
 		Use:   "public",

--- a/go_node_engine/config/config.go
+++ b/go_node_engine/config/config.go
@@ -17,6 +17,7 @@ type ConfFile struct {
 	ClusterPort     int              `json:"cluster_port"`
 	AppLogs         string           `json:"app_logs"`
 	OverlayNetwork  string           `json:"overlay_network"`
+	PublicIp        bool             `json:"public_ip"`
 	NetPort         int              `json:"overlay_network_port"`
 	CertFile        string           `json:"mqtt_cert_file"`
 	KeyFile         string           `json:"mqtt_key_file"`
@@ -145,6 +146,7 @@ func GenDefaultConfig() ConfFile {
 		ClusterPort:    10100,
 		AppLogs:        DEFAULT_LOG_DIR,
 		OverlayNetwork: AUTO_OAK_NETWORK,
+		PublicIp:       false,
 		NetPort:        0,
 		Virtualizations: []Virtualization{
 			{

--- a/go_node_engine/config/config.go
+++ b/go_node_engine/config/config.go
@@ -4,12 +4,20 @@ import (
 	"encoding/json"
 	"fmt"
 	"go_node_engine/logger"
-	"go_node_engine/model"
 	"os"
 )
 
 var DEFAULT_LOG_DIR = "/tmp"
 var AUTO_OAK_NETWORK = "default"
+
+// RuntimeType is the type of runtime that the node executes
+type RuntimeType string
+
+// RuntimeType constants
+const (
+	CONTAINER_RUNTIME RuntimeType = "docker"
+	UNIKERNEL_RUNTIME RuntimeType = "unikernel"
+)
 
 type ConfFile struct {
 	ConfVersion     string           `json:"conf_version"`
@@ -151,7 +159,7 @@ func GenDefaultConfig() ConfFile {
 		Virtualizations: []Virtualization{
 			{
 				Name:    "containerd",
-				Runtime: string(model.CONTAINER_RUNTIME),
+				Runtime: string(CONTAINER_RUNTIME),
 				Active:  true,
 				Config:  []string{},
 			},

--- a/go_node_engine/model/Node.go
+++ b/go_node_engine/model/Node.go
@@ -168,7 +168,12 @@ func getIp() string {
 		if err != nil {
 			logger.ErrorLogger().Printf("%v", err.Error())
 		}
-		defer req.Body.Close()
+		defer func(Body io.ReadCloser) {
+			err := Body.Close()
+			if err != nil {
+				logger.ErrorLogger().Printf("%v", err.Error())
+			}
+		}(req.Body)
 
 		body, err := io.ReadAll(req.Body)
 		if err != nil {

--- a/go_node_engine/model/Node.go
+++ b/go_node_engine/model/Node.go
@@ -156,6 +156,8 @@ func getIp() string {
 		logger.ErrorLogger().Fatal(err)
 	}
 	if conf.PublicIp {
+
+		// Only get public IP every nth update cycle to prevent API overload
 		if SlowUpdateCounter != 0 {
 			SlowUpdateCounter = (SlowUpdateCounter + 1) % SlowUpdateFactor
 			return node.Ip

--- a/go_node_engine/model/Node.go
+++ b/go_node_engine/model/Node.go
@@ -2,9 +2,12 @@ package model
 
 import (
 	"fmt"
+	"go_node_engine/config"
 	"go_node_engine/logger"
 	"go_node_engine/model/gpu"
+	"io"
 	"net"
+	"net/http"
 	"os"
 	"runtime"
 	"strconv"
@@ -17,16 +20,14 @@ import (
 	psnet "github.com/shirou/gopsutil/net"
 )
 
-// RuntimeType is the type of runtime that the node executes
-type RuntimeType string
-
-// RuntimeType constants
-const (
-	CONTAINER_RUNTIME RuntimeType = "docker"
-	UNIKERNEL_RUNTIME RuntimeType = "unikernel"
-)
+type RuntimeType = config.RuntimeType
 
 // AddonType is the type of addon that the node supports
+var (
+	CONTAINER_RUNTIME config.RuntimeType = config.CONTAINER_RUNTIME
+	UNIKERNEL_RUNTIME config.RuntimeType = config.UNIKERNEL_RUNTIME
+)
+
 type AddonType string
 
 const (
@@ -36,26 +37,26 @@ const (
 
 // Node is the struct that describes the node
 type Node struct {
-	Id              string            `json:"id"`
-	Host            string            `json:"host"`
-	Ip              string            `json:"ip"`
-	Port            string            `json:"port"`
-	SystemInfo      map[string]string `json:"system_info"`
-	CpuUsage        float64           `json:"cpu"`
-	CpuCores        int               `json:"free_cores"`
-	CpuArch         string            `json:"architecture"`
-	MemoryUsed      float64           `json:"memory"`
-	MemoryMB        int               `json:"memory_free_in_MB"`
-	DiskInfo        map[string]string `json:"disk_info"`
-	NetworkInfo     map[string]string `json:"network_info"`
-	GpuDriver       string            `json:"gpu_driver"`
-	GpuUsage        float64           `json:"gpu_usage"`
-	GpuCores        int               `json:"gpu_cores"`
-	GpuTemp         float64           `json:"gpu_temp"`
-	GpuMemUsage     float64           `json:"gpu_mem_used"`
-	GpuTotMem       float64           `json:"gpu_tot_mem"`
-	Technology      []RuntimeType     `json:"technology"`
-	SupportedAddons []AddonType       `json:"supported_addons"`
+	Id              string               `json:"id"`
+	Host            string               `json:"host"`
+	Ip              string               `json:"ip"`
+	Port            string               `json:"port"`
+	SystemInfo      map[string]string    `json:"system_info"`
+	CpuUsage        float64              `json:"cpu"`
+	CpuCores        int                  `json:"free_cores"`
+	CpuArch         string               `json:"architecture"`
+	MemoryUsed      float64              `json:"memory"`
+	MemoryMB        int                  `json:"memory_free_in_MB"`
+	DiskInfo        map[string]string    `json:"disk_info"`
+	NetworkInfo     map[string]string    `json:"network_info"`
+	GpuDriver       string               `json:"gpu_driver"`
+	GpuUsage        float64              `json:"gpu_usage"`
+	GpuCores        int                  `json:"gpu_cores"`
+	GpuTemp         float64              `json:"gpu_temp"`
+	GpuMemUsage     float64              `json:"gpu_mem_used"`
+	GpuTotMem       float64              `json:"gpu_tot_mem"`
+	Technology      []config.RuntimeType `json:"technology"`
+	SupportedAddons []AddonType          `json:"supported_addons"`
 	Overlay         bool
 	OverlaySocket   string
 	LogDirectory    string
@@ -75,7 +76,7 @@ func GetNodeInfo() *Node {
 			CpuCores:        getCpuCores(),
 			CpuArch:         runtime.GOARCH,
 			Port:            getPort(),
-			Technology:      make([]RuntimeType, 0),
+			Technology:      make([]config.RuntimeType, 0),
 			SupportedAddons: make([]AddonType, 0),
 			Overlay:         false,
 			OverlaySocket:   "/etc/netmanager/netmanager.sock",
@@ -102,6 +103,7 @@ func (n *Node) SetOverlaySocket(socket string) {
 func GetDynamicInfo() Node {
 	node.updateDynamicInfo()
 	return Node{
+		Ip:          node.Ip,
 		CpuUsage:    node.CpuUsage,
 		CpuCores:    node.CpuCores,
 		MemoryUsed:  node.MemoryUsed,
@@ -145,6 +147,28 @@ func SetNodeId(id string) {
 }
 
 func getIp() string {
+	conf, err := config.GetConfFileManager().Get()
+	if err != nil {
+		logger.ErrorLogger().Fatal(err)
+	}
+	if conf.PublicIp {
+		//Todo remove
+		logger.InfoLogger().Printf("using public ip")
+
+		req, err := http.Get("ifconfig.co")
+		if err != nil {
+			return err.Error()
+		}
+		defer req.Body.Close()
+
+		body, err := io.ReadAll(req.Body)
+		if err != nil {
+			return err.Error()
+		}
+
+		return string(body)
+	}
+
 	addresses, err := net.InterfaceAddrs()
 	if err != nil {
 		return ""
@@ -259,12 +283,12 @@ func getPort() string {
 }
 
 // AddSupportedTechnology adds a supported technology to the node
-func (n *Node) AddSupportedTechnology(tech RuntimeType) {
+func (n *Node) AddSupportedTechnology(tech config.RuntimeType) {
 	n.Technology = append(n.Technology, tech)
 }
 
 // GetSupportedTechnologyList returns the list of supported technologies
-func (n *Node) GetSupportedTechnologyList() []RuntimeType {
+func (n *Node) GetSupportedTechnologyList() []config.RuntimeType {
 	return n.Technology
 }
 

--- a/go_node_engine/model/Node.go
+++ b/go_node_engine/model/Node.go
@@ -28,6 +28,10 @@ var (
 	UNIKERNEL_RUNTIME config.RuntimeType = config.UNIKERNEL_RUNTIME
 )
 
+const SlowUpdateFactor = 60
+
+var SlowUpdateCounter = 0
+
 type AddonType string
 
 const (
@@ -152,12 +156,15 @@ func getIp() string {
 		logger.ErrorLogger().Fatal(err)
 	}
 	if conf.PublicIp {
-		//Todo remove
-		logger.InfoLogger().Printf("using public ip")
+		if SlowUpdateCounter != 0 {
+			SlowUpdateCounter = (SlowUpdateCounter + 1) % SlowUpdateFactor
+			return node.Ip
+		}
+		SlowUpdateCounter = (SlowUpdateCounter + 1) % SlowUpdateFactor
 
-		req, err := http.Get("ifconfig.co")
+		req, err := http.Get("https://ifconfig.co")
 		if err != nil {
-			return err.Error()
+			logger.ErrorLogger().Printf("%v", err.Error())
 		}
 		defer req.Body.Close()
 
@@ -166,7 +173,7 @@ func getIp() string {
 			return err.Error()
 		}
 
-		return string(body)
+		return string(body[:len(body)-1])
 	}
 
 	addresses, err := net.InterfaceAddrs()

--- a/go_node_engine/model/Node.go
+++ b/go_node_engine/model/Node.go
@@ -28,8 +28,7 @@ var (
 	UNIKERNEL_RUNTIME config.RuntimeType = config.UNIKERNEL_RUNTIME
 )
 
-const SlowUpdateFactor = 60
-
+const SlowUpdateFactor = 60 // For updating certain Node parameters at a lower frequency
 var SlowUpdateCounter = 0
 
 type AddonType string

--- a/go_node_engine/mqtt/MqttClient.go
+++ b/go_node_engine/mqtt/MqttClient.go
@@ -29,7 +29,7 @@ var connectHandler mqtt.OnConnectHandler = func(client mqtt.Client) {
 	logger.InfoLogger().Println("Connected to the MQTT broker")
 
 	topicsQosMap := make(map[string]byte)
-	for key, _ := range TOPICS {
+	for key := range TOPICS {
 		topicsQosMap[key] = 1
 	}
 

--- a/go_node_engine/virtualization/ContainersManagement.go
+++ b/go_node_engine/virtualization/ContainersManagement.go
@@ -94,7 +94,7 @@ func checkAdditionalRuntimePlugins() {
 		if ok {
 			runtimes, ok := ctd["runtimes"].(map[string]interface{})
 			if ok {
-				for runtimeName, _ := range runtimes {
+				for runtimeName := range runtimes {
 					logger.InfoLogger().Printf("Adding compatibility custom runtime %s configured in containerd config file %s", runtimeName, CONTAINERD_CONFIG_PATH)
 					model.GetNodeInfo().AddSupportedTechnology(model.RuntimeType(runtimeName))
 					registerRuntimeLink(runtimeName, GetContainerdRuntime)

--- a/go_node_engine/virtualization/ContainersManagement.go
+++ b/go_node_engine/virtualization/ContainersManagement.go
@@ -390,6 +390,10 @@ func (r *ContainerRuntime) ResourceMonitoring(every time.Duration, notifyHandler
 					task, err := container.Task(r.ctx, nil)
 					if err != nil {
 						logger.ErrorLogger().Printf("Unable to fetch container task: %v", err)
+						err := r.removeContainer(container)
+						if err != nil {
+							return
+						}
 						continue
 					}
 
@@ -454,11 +458,9 @@ func (r *ContainerRuntime) removeContainer(container containerd.Container) error
 	if err != nil {
 		return fmt.Errorf("Unable to fetch container task: %v", err)
 	}
-	if err == nil {
-		err = killTask(r.ctx, task, container)
-		if err != nil {
-			return fmt.Errorf("Unable to fetch kill task: %v", err)
-		}
+	err = killTask(r.ctx, task, container)
+	if err != nil {
+		return fmt.Errorf("Unable to fetch kill task: %v", err)
 	}
 	err = container.Delete(r.ctx)
 	if err != nil {


### PR DESCRIPTION
When the NodeEngine is still managing a service that no longer exists on the orchestration plane and the service was not correctly undeployed (e.g. if the root orchestrator was down) the NodeEngine will permanently report the error
```
ERROR-2025/07/02 23:01:32 ContainersManagement.go:392: Unable to fetch container task: no running task found: task Nginx.Test.curlv4.test.instance.1 not found: not found
ERROR-2025/07/02 23:01:32 ContainersManagement.go:392: Unable to fetch container task: no running task found: task Nginx.Test.nginx.test.instance.1 not found: not found
````
This also prevents a service of this name being deployed, resulting in phantom scheduling errors with the message
```
NoActiveClusterWithCapacity
```
To prevent this the NodeEngine should clean up any containers which it cannot find a task for
