### PR TITLE
Cleanup Hanging Containers

### DIFF
--- a/go_node_engine/virtualization/ContainersManagement.go
+++ b/go_node_engine/virtualization/ContainersManagement.go
@@ -390,6 +390,10 @@ func (r *ContainerRuntime) ResourceMonitoring(every time.Duration, notifyHandler
 					task, err := container.Task(r.ctx, nil)
 					if err != nil {
 						logger.ErrorLogger().Printf("Unable to fetch container task: %v", err)
+						err := r.removeContainer(container)
+						if err != nil {
+							return
+						}
 						continue
 					}
 
@@ -454,11 +458,9 @@ func (r *ContainerRuntime) removeContainer(container containerd.Container) error
 	if err != nil {
 		return fmt.Errorf("Unable to fetch container task: %v", err)
 	}
-	if err == nil {
-		err = killTask(r.ctx, task, container)
-		if err != nil {
-			return fmt.Errorf("Unable to fetch kill task: %v", err)
-		}
+	err = killTask(r.ctx, task, container)
+	if err != nil {
+		return fmt.Errorf("Unable to fetch kill task: %v", err)
 	}
 	err = container.Delete(r.ctx)
 	if err != nil {


### PR DESCRIPTION
When the NodeEngine is still managing a service that no longer exists on the orchestration plane and the service was not correctly undeployed (e.g. if the root orchestrator was down) the NodeEngine will permanently report the error
```
ERROR-2025/07/02 23:01:32 ContainersManagement.go:392: Unable to fetch container task: no running task found: task Nginx.Test.curlv4.test.instance.1 not found: not found
ERROR-2025/07/02 23:01:32 ContainersManagement.go:392: Unable to fetch container task: no running task found: task Nginx.Test.nginx.test.instance.1 not found: not found
````
This also prevents a service of this name being deployed, resulting in phantom scheduling errors with the message
```
NoActiveClusterWithCapacity
```
To prevent this the NodeEngine should clean up any containers which it cannot find a task for
