### PR TITLE
pull_policy:never for local-service-manager overrides

### DIFF
--- a/cluster_orchestrator/override-local-service-manager.yml
+++ b/cluster_orchestrator/override-local-service-manager.yml
@@ -2,4 +2,5 @@ version: "3.3"
 
 services:
   cluster_service_manager:
+    pull_policy: never
     image: local_cluster_service_manager

--- a/root_orchestrator/override-local-service-manager.yml
+++ b/root_orchestrator/override-local-service-manager.yml
@@ -2,4 +2,5 @@ version: "3.3"
 
 services:
   root_service_manager:
+    pull_policy: never
     image: local_root_service_manager


### PR DESCRIPTION
Fixes #458 

This pull request introduces a small but important configuration update to the Docker Compose override files for both the cluster and root service managers. The change ensures that Docker will not attempt to pull the images from a remote registry and will instead use the locally built images.

- Docker Compose override updates:
  * Added `pull_policy: never` to the `cluster_service_manager` service in `cluster_orchestrator/override-local-service-manager.yml` to force Docker to use the local image.
  * Added `pull_policy: never` to the `root_service_manager` service in `root_orchestrator/override-local-service-manager.yml` to force Docker to use the local image.