### PR TITLE
Fix auto re-deployment routine

### DIFF
--- a/cluster_orchestrator/cluster-manager/clients/job_management.py
+++ b/cluster_orchestrator/cluster-manager/clients/job_management.py
@@ -111,16 +111,19 @@ def update_status(job_id, instance_number, status, status_detail=None):
     if job is None:
         return
 
-    # don't update job to running
-    if status != DeploymentStatus.RUNNING.value:
-        job["status"] = status
-
     if job.get("instance_list") is not None:
         for instance in job.get("instance_list"):
             if instance["instance_number"] == instance_number:
                 instance["status"] = status
                 if status_detail is not None:
                     instance["status_detail"] = status_detail
+
+    # Update job-level status, but only set RUNNING once all instances are running
+    if status != DeploymentStatus.RUNNING.value:
+        job["status"] = status
+    elif all(i["status"] == DeploymentStatus.RUNNING.value
+             for i in job.get("instance_list", [])):
+        job["status"] = status
 
     job_operations.update_job(job_id, job)
 
@@ -234,7 +237,7 @@ def delete_job_instance(job_id: int, instance_number: int, erase: bool = True):
                     f"Deleted instance {instance['instance_number']} of job {job_id} from DB"
                 )
 
-    if len(instance_list) <= deleted_job:
+    if erase and len(instance_list) <= deleted_job:
         job_operations.delete_job(job_id)
         logger.info(f"Deleted job {job_id} from DB as all instances were removed")
         return {}

--- a/cluster_orchestrator/cluster-manager/clients/job_management.py
+++ b/cluster_orchestrator/cluster-manager/clients/job_management.py
@@ -121,8 +121,7 @@ def update_status(job_id, instance_number, status, status_detail=None):
     # Update job-level status, but only set RUNNING once all instances are running
     if status != DeploymentStatus.RUNNING.value:
         job["status"] = status
-    elif all(i["status"] == DeploymentStatus.RUNNING.value
-             for i in job.get("instance_list", [])):
+    elif all(i["status"] == DeploymentStatus.RUNNING.value for i in job.get("instance_list", [])):
         job["status"] = status
 
     job_operations.update_job(job_id, job)

--- a/cluster_orchestrator/cluster-manager/ext_requests/system_manager_requests.py
+++ b/cluster_orchestrator/cluster-manager/ext_requests/system_manager_requests.py
@@ -9,6 +9,7 @@ from clients.my_prometheus_client import prometheus_set_metrics
 from oakestra_utils.types.statuses import (
     DeploymentStatus,
     NegativeSchedulingStatus,
+    PositiveSchedulingStatus,
     convert_to_status,
 )
 
@@ -67,6 +68,12 @@ def trigger_undeploy_and_re_deploy(service, instance):
     try:
         job_management.delete_job_instance(
             service.get("_id"), instance.get("instance_number"), erase=False
+        )
+        job_management.update_status(
+            service.get("_id"),
+            instance.get("instance_number"),
+            PositiveSchedulingStatus.REQUESTED.value,
+            status_detail="Waiting for scheduling decision",
         )
         scheduler_request_deploy(service, instance.get("instance_number"))
     except Exception as e:

--- a/scheduler/calculate/scheduling.go
+++ b/scheduler/calculate/scheduling.go
@@ -67,6 +67,7 @@ func PerformSchedulingRequest[T interfaces.ResourceList](job T, algorithm interf
 		return err
 	}
 
+	logger.InfoLogger().Printf("Scheduled job %s to candidate %s", job.GetId(), placementCandidate.GetId())
 	err = manager.Deploy(job.GetId(), placementCandidate.GetId(), true)
 
 	return err


### PR DESCRIPTION
Fixes #474 

The bug consists of two components:
1. Dead service instances were not being re-deployed
2. The status was not being set correctly

The fixes:
1. Simple one liner that prevented the cluster manager from deleting a job when it's only service was being re-deplyoed
2. The statuses are now being updated more thoroughly so when observing the job statuses directly in the mongo db they are being set correctly, however since the service is being stopped and started quite rapidly, the update window to the root is too small. The result is that at the root (i.e. via the CLI or dashbaord) the job will always appear dead