### PR TITLE
Change PR_COMMIT to use HEAD instead of SHA

### DIFF
--- a/.github/workflows/oneshot_testbed_workflow_run.yml
+++ b/.github/workflows/oneshot_testbed_workflow_run.yml
@@ -35,4 +35,4 @@ jobs:
           AWX_TEMPLATE_ID: 18 # Job Workflow Template ID for Oneshot Testbed Execution
           PR_BRANCH: ${{ github.event.workflow_run.head_branch }}
           PR_USER: ${{ github.event.workflow_run.head_commit.author.name }}
-          PR_COMMIT: ${{ github.event.workflow_run.head_sha }}
+          PR_COMMIT: HEAD


### PR DESCRIPTION
This allows us to re-run the piepline on latest commits without re-approvals