### PR TITLE
Fix local service manager override and configuration

### DIFF
--- a/scripts/StartOakestraCluster.sh
+++ b/scripts/StartOakestraCluster.sh
@@ -228,9 +228,13 @@ if [ "$OAKESTRA_VERSION" != "main" ]; then
 fi
 
 if sudo docker ps -a | grep oakestra/cluster >/dev/null 2>&1; then
-  echo 🚨 Oakestra cluster containers are already running. Please stop them before starting another cluster on this machine.
-  echo 🪫 You can turn off the current cluster using: \$ docker compose -f ~/.oakestra/cluster_orchestrator/cluster-orchestrator.yml down
-  exit 1
+    echo 🚨 Detected some Oakestra cluster containers already running. It is recommended to stop them before starting a new cluster.
+    echo Do you wish to continue anyway? \(y/n\)
+    read answer
+    if [ "$answer" != "y" ]; then
+      echo Exiting without starting Oakestra Cluster.
+      exit 0
+    fi
 fi
 
 command_exec="LIB_BRANCH=${OAKESTRA_VERSION} sudo -E docker compose -f ${COMPOSE_FILE} ${OAK_OVERRIDES} up ${BUILD_FLAG} -d"

--- a/scripts/StartOakestraCluster.sh
+++ b/scripts/StartOakestraCluster.sh
@@ -210,7 +210,7 @@ fi
 
 # If non-main branch and no override provided, update custom version of service manager to prevent potential issues with network policies in non-main branches
 if [ "$OAKESTRA_VERSION" != "main" ]; then
-    if [[ ! "$OVERRIDE_FILES" == *"override-no-network.yml"* ]] && [[ ! "$OVERRIDE_FILES" == *"override-custom-service-manager-version.yml"* ]]; then
+    if [[ ! "$OVERRIDE_FILES" == *"override-no-network.yml"* ]] && [[ ! "$OVERRIDE_FILES" == *"override-custom-service-manager-version.yml"* ]] && [[ ! "$OVERRIDE_FILES" == *"override-local-service-manager.yml"* ]]; then
         echo "🕸️ Setting network to latest alpha release"
         if is_tag "$OAKESTRA_VERSION"; then
             ALPHA_TAG=$(echo $OAKESTRA_VERSION | sed 's/alpha-//g')

--- a/scripts/StartOakestraFull.sh
+++ b/scripts/StartOakestraFull.sh
@@ -171,9 +171,13 @@ if [ ! -z "$OAKESTRA_VERSION" ]; then
 fi
 
 if sudo docker ps -a | grep oakestra >/dev/null 2>&1; then
-  echo 🚨 Oakestra containers are already running. Please stop them before starting a new 1-DOC cluster.
-  echo 🪫 You can turn off the current cluster using: \$ docker compose -f ~/.oakestra/1-DOC.yaml down
-  exit 1
+  echo 🚨 Detected some Oakestra containers already running. It is recommended to stop them before starting a new 1-DOC cluster.
+  echo Do you wish to continue anyway? \(y/n\)
+  read answer
+  if [ "$answer" != "y" ]; then
+    echo Exiting without starting Oakestra 1-DOC.
+    exit 0
+  fi
 fi
 
 command_exec="sudo -E docker compose -f 1-DOC.yaml ${OAK_OVERRIDES} up -d"

--- a/scripts/StartOakestraRoot.sh
+++ b/scripts/StartOakestraRoot.sh
@@ -135,7 +135,7 @@ fi
 
 # If non-main branch and no override provided, update custom version of service manager to prevent potential issues with network policies in non-main branches
 if [ "$OAKESTRA_VERSION" != "main" ]; then
-    if [[ ! "$OVERRIDE_FILES" == *"override-no-network.yml"* ]] && [[ ! "$OVERRIDE_FILES" == *"override-custom-service-manager-version.yml"* ]]; then
+    if [[ ! "$OVERRIDE_FILES" == *"override-no-network.yml"* ]] && [[ ! "$OVERRIDE_FILES" == *"override-custom-service-manager-version.yml"* ]] && [[ ! "$OVERRIDE_FILES" == *"override-local-service-manager.yml"* ]]; then
         echo "🕸️ Setting network to latest alpha release"
         if is_tag "$OAKESTRA_VERSION"; then
             ALPHA_TAG=$(echo $OAKESTRA_VERSION | sed 's/alpha-//g')

--- a/scripts/StartOakestraRoot.sh
+++ b/scripts/StartOakestraRoot.sh
@@ -153,9 +153,13 @@ if [ "$OAKESTRA_VERSION" != "main" ]; then
 fi
 
 if sudo docker ps -a | grep oakestra/root >/dev/null 2>&1; then
-  echo 🚨 Oakestra root containers are already running. Please stop them before starting the root orchestrator.
-  echo 🪫 You can turn off the current root using: \$ docker compose -f ~/.oakestra/root_orchestrator/root-orchestrator.yml down
-  exit 1
+    echo 🚨 Detected some Oakestra Root containers already running. It is recommended to stop them before starting a new Root orchestrator.
+    echo Do you wish to continue anyway? \(y/n\)
+    read answer
+    if [ "$answer" != "y" ]; then
+      echo Exiting without starting Oakestra Root Orchestrator.
+      exit 0
+    fi
 fi
 
 command_exec="LIB_BRANCH=${OAKESTRA_VERSION} sudo -E docker compose -f ${COMPOSE_FILE} ${OAK_OVERRIDES} up ${BUILD_FLAG} -d"


### PR DESCRIPTION
This pull request updates the startup scripts for Oakestra clusters to:
- improve user experience and flexibility when existing containers are detected
- fix a bug affecting how the local service manager override was applied

**User Experience Improvements:**

* The scripts (`StartOakestraCluster.sh`, `StartOakestraRoot.sh`, and `StartOakestraFull.sh`) now prompt the user for confirmation if Oakestra containers are already running, instead of immediately exiting. This allows users to choose whether to proceed or exit without starting a new cluster. [[1]](diffhunk://#diff-6e8db02d28de607f77779b4b5e5638710e922301ecced52fbefc9de5535aeb13L231-R237) [[2]](diffhunk://#diff-72306cb64e5551d30fbe0223da602238a049ab4dd058508222db33d2e44b5daeL156-R162) [[3]](diffhunk://#diff-c364e9862a4e02cedda33e2cbb2f26a594808b2942a71b95d921b1d6e4ba2857L174-R180)

**Override Handling Enhancements:**

* In both `StartOakestraCluster.sh` and `StartOakestraRoot.sh`, the condition for updating the custom service manager version in non-main branches now also checks for the presence of the `override-local-service-manager.yml` file, providing more precise control over overrides. [[1]](diffhunk://#diff-6e8db02d28de607f77779b4b5e5638710e922301ecced52fbefc9de5535aeb13L213-R213) [[2]](diffhunk://#diff-72306cb64e5551d30fbe0223da602238a049ab4dd058508222db33d2e44b5daeL138-R138)