### PR TITLE
Fix direct contraints

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -4,7 +4,7 @@
 
 Oakestra is a **lightweight orchestration platform for edge computing**. Unlike Kubernetes or K3s, which were designed for cloud-grade machines, Oakestra targets heterogeneous, resource-constrained edge devices. The entire root + cluster stack runs in ~1 GB RAM. A worker node needs only 100 MB RAM and 50 MB disk.
 
-The platform orchestrates containerised workloads (Docker, containerd) and unikernels across a two-level hierarchy: **root → clusters → workers**. Applications are described via SLA (Service Level Agreement) JSON documents that encode resource constraints, placement preferences, and networking requirements. The scheduler places each microservice on the best-fit worker using a pluggable algorithm (default: `rootBestCpuMemFit`).
+The platform orchestrates containerised workloads (Docker, containerd) and unikernels across a two-level hierarchy: **root → clusters → workers**. Applications are described via SLA (Service Level Agreement) JSON documents that encode resource constraints, placement preferences, and networking requirements. The scheduler places each microservice on the best-fit worker using a pluggable algorithm (default: `bestCpuMemFit`).
 
 Current develop version: see `version.txt`.
 

--- a/cluster_orchestrator/docker-compose.yml
+++ b/cluster_orchestrator/docker-compose.yml
@@ -135,6 +135,7 @@ services:
     ports:
       - "10105:10105"
     environment:
+      - ORCHESTRATION_PLANE=cluster
       - API_PORT=10105
       - MANAGER_URL=cluster_manager
       - MANAGER_PORT=10100

--- a/root_orchestrator/docker-compose.yml
+++ b/root_orchestrator/docker-compose.yml
@@ -165,6 +165,7 @@ services:
     ports:
       - "10004:10004"
     environment:
+      - ORCHESTRATION_PLANE=root
       - API_PORT=10004
       - MANAGER_URL=system_manager
       - MANAGER_PORT=10000

--- a/run-a-cluster/1-DOC.yaml
+++ b/run-a-cluster/1-DOC.yaml
@@ -40,6 +40,7 @@ services:
       - root_service_manager
       - jwt_generator
     environment:
+      - ORCHESTRATION_PLANE=root
       - ROOT_MONGO_URL=mongo
       - ROOT_MONGO_PORT=10007
       - ROOT_SCHEDULER_URL=root_scheduler
@@ -315,6 +316,7 @@ services:
     expose:
       - "10105"
     environment:
+      - ORCHESTRATION_PLANE=cluster
       - API_PORT=10105
       - MANAGER_URL=cluster_manager
       - MANAGER_PORT=10100

--- a/run-a-cluster/root-orchestrator.yml
+++ b/run-a-cluster/root-orchestrator.yml
@@ -171,6 +171,7 @@ services:
     ports:
       - "10004:10004"
     environment:
+      - ORCHESTRATION_PLANE=root
       - MY_PORT=10004
       - SYSTEM_MANAGER_URL=system_manager
       - SYSTEM_MANAGER_PORT=10000

--- a/scheduler/Dockerfile
+++ b/scheduler/Dockerfile
@@ -18,4 +18,6 @@ ENV RESOURCE_ABSTRACTOR_PORT=11011
 
 ENV REDIS_ADDR=redis://:rootRedis@redis:6379
 
+ENV DEBUG=False
+
 ENTRYPOINT ["./scheduler"]

--- a/scheduler/calculate/schedulers/bestCpuMemFit/calculate.go
+++ b/scheduler/calculate/schedulers/bestCpuMemFit/calculate.go
@@ -3,10 +3,13 @@ package bestCpuMemFit
 import (
 	"encoding/json"
 	"errors"
+	"os"
 	"scheduler/calculate/schedulers/interfaces"
 	"scheduler/logger"
 	"slices"
 )
+
+var Plane = os.Getenv("ORCHESTRATION_PLANE")
 
 type CpuMemConstraints struct {
 	interfaces.GenericConstraints
@@ -45,8 +48,13 @@ func (r CpuMemResources) ResourceConstraints() map[string]string {
 	for _, constraint := range r.Constraints {
 		logger.DebugLogger().Printf("Constraint: %+v", constraint)
 		if constraint.Type == "direct" {
-			constraints["cluster_name"] = constraint.Cluster
-			constraints["node_name"] = constraint.Node
+			var c string
+			if Plane == "cluster" {
+				c = constraint.Node
+			} else {
+				c = constraint.Cluster
+			}
+			constraints["candidate_name"] = c
 		}
 	}
 	return constraints

--- a/scheduler/calculate/schedulers/bestCpuMemFit/calculate.go
+++ b/scheduler/calculate/schedulers/bestCpuMemFit/calculate.go
@@ -1,4 +1,4 @@
-package rootBestCpuMemFit
+package bestCpuMemFit
 
 import (
 	"encoding/json"

--- a/scheduler/calculate/schedulers/bestCpuMemFit/calculate_test.go
+++ b/scheduler/calculate/schedulers/bestCpuMemFit/calculate_test.go
@@ -1,4 +1,4 @@
-package rootBestCpuMemFit
+package bestCpuMemFit
 
 import (
 	"encoding/json"

--- a/scheduler/calculate/schedulers/rootRandom/calculate.go
+++ b/scheduler/calculate/schedulers/rootRandom/calculate.go
@@ -1,4 +1,4 @@
-package rootBestCpuMemFit
+package bestCpuMemFit
 
 import (
 	"encoding/json"

--- a/scheduler/cmd/main.go
+++ b/scheduler/cmd/main.go
@@ -2,10 +2,21 @@ package main
 
 import (
 	"log"
+	"os"
 	"scheduler/api"
+	"scheduler/logger"
+	"strconv"
 )
 
+func setup() {
+	debugMode, err := strconv.ParseBool(os.Getenv("DEBUG"))
+	if err == nil && debugMode {
+		logger.SetDebugMode()
+	}
+}
+
 func main() {
+	setup()
 	go func() {
 		StartTaskQueueServer()
 		log.Fatal("Task queue server stopped")

--- a/scheduler/cmd/tasks.go
+++ b/scheduler/cmd/tasks.go
@@ -6,7 +6,7 @@ import (
 	"log"
 	"os"
 	"scheduler/calculate"
-	"scheduler/calculate/schedulers/rootBestCpuMemFit"
+	"scheduler/calculate/schedulers/bestCpuMemFit"
 	"scheduler/logger"
 
 	"github.com/hibiken/asynq"
@@ -17,7 +17,7 @@ const TaskTypeScheduler = "schedule:job"
 var RedisAddr = os.Getenv("REDIS_ADDR")
 
 // A determines scheduler to use
-type A = rootBestCpuMemFit.BestCpuMemFit
+type A = bestCpuMemFit.BestCpuMemFit
 
 func StartTaskQueueServer() {
 	redisOpt, err := asynq.ParseRedisURI(RedisAddr)

--- a/scheduler/requests/resource/resourceAbstractorRequests.go
+++ b/scheduler/requests/resource/resourceAbstractorRequests.go
@@ -35,9 +35,8 @@ func formatQuery(requestParameters map[string]string, interestedResources []stri
 	if resources != "" {
 		sb.WriteString("&")
 		sb.WriteString(resources)
-		return sb.String()
 	}
-	return sb.String()[:sb.Len()-1]
+	return sb.String()
 }
 
 func formatRequestParameters(r map[string]string) string {
@@ -45,14 +44,13 @@ func formatRequestParameters(r map[string]string) string {
 		return ""
 	}
 	var sb strings.Builder
-	sb.WriteString("?")
 	for k, v := range r {
 		if v == "" {
 			continue
 		}
 		sb.WriteString(fmt.Sprintf("%s=%s&", k, v))
 	}
-	return sb.String()[:sb.Len()-1]
+	return strings.TrimSuffix(sb.String(), "&")
 }
 
 func formatInterestedResources(interestedResources []string) string {
@@ -65,7 +63,7 @@ func formatInterestedResources(interestedResources []string) string {
 		sb.WriteString(",")
 	}
 
-	return sb.String()[:sb.Len()-1]
+	return strings.TrimSuffix(sb.String(), ",")
 }
 
 func AvailableResources[T interfaces.ResourceList](data *[]T, requestParameters map[string]string, interestedResources []string) error {

--- a/scheduler/requests/resource/resourceAbstractorRequests_test.go
+++ b/scheduler/requests/resource/resourceAbstractorRequests_test.go
@@ -1,0 +1,34 @@
+package resource
+
+import "testing"
+
+func TestFormatRequestParameters_EmptyValuesOnly(t *testing.T) {
+	params := map[string]string{"candidate_name": ""}
+
+	got := formatRequestParameters(params)
+
+	if got != "" {
+		t.Fatalf("expected empty string, got %q", got)
+	}
+}
+
+func TestFormatQuery_OnlyActiveWhenNoFilters(t *testing.T) {
+	got := formatQuery(map[string]string{"candidate_name": ""}, nil)
+
+	want := "?active=true"
+	if got != want {
+		t.Fatalf("expected %q, got %q", want, got)
+	}
+}
+
+func TestFormatQuery_WithRequestAndResources(t *testing.T) {
+	got := formatQuery(
+		map[string]string{"candidate_name": "cluster-a"},
+		[]string{"_id", "memory"},
+	)
+
+	want := "?active=true&candidate_name=cluster-a&_id,memory"
+	if got != want {
+		t.Fatalf("expected %q, got %q", want, got)
+	}
+}


### PR DESCRIPTION
Fixes #505 

This fixes the formatting of the constrains when they are being sent to the resource abstractor. A small unit test was implemented to prevent tricky formatting bugs from emerging again.

The core of the bug is that the scheduler assumed it was at the root, when the resource abstractor makes no such assumptions.
This has now been fixed and the scheduler uses an env variable to determine if it's a the root or cluster.

The rootBestCpuMemFit scheduling algorithm has also been renamed to bestCpuMemFit as it's used at both orchestration planes.