### PR TITLE
fix(node-engine): prevent panic when containerd config has no plugins

### DIFF
--- a/go_node_engine/virtualization/ContainersManagement.go
+++ b/go_node_engine/virtualization/ContainersManagement.go
@@ -37,11 +37,8 @@ import (
 
 func init() {
 	virtrt.Register(string(model.CONTAINER_RUNTIME), newContainerdRuntime)
-	plugins := findAdditionalRuntimePlugins()
-	if plugins != nil {
-		for additionalName := range findAdditionalRuntimePlugins() {
-			virtrt.Register(additionalName, newContainerdRuntime)
-		}
+	for additionalName := range findAdditionalRuntimePlugins() {
+		virtrt.Register(additionalName, newContainerdRuntime)
 	}
 }
 
@@ -104,17 +101,22 @@ func newContainerdRuntime(_ virtrt.RuntimeInfo) virtrt.Runtime {
 // Parses TOML directly: containerd's v2 LoadConfig rejects legacy short-form
 // disabled_plugins entries (e.g. "cri") that ship with Docker's containerd.
 func findAdditionalRuntimePlugins() iter.Seq[string] {
-	data, err := os.ReadFile(CONTAINERD_CONFIG_PATH)
+	return findAdditionalRuntimePluginsAt(CONTAINERD_CONFIG_PATH)
+}
+
+func findAdditionalRuntimePluginsAt(path string) iter.Seq[string] {
+	empty := maps.Keys(map[string]interface{}{})
+	data, err := os.ReadFile(path)
 	if err != nil {
 		logger.ErrorLogger().Printf("Unable to read containerd config file: %v", err)
-		return nil
+		return empty
 	}
 	var containerdConfig struct {
 		Plugins map[string]interface{} `toml:"plugins"`
 	}
 	if err := toml.Unmarshal(data, &containerdConfig); err != nil {
 		logger.ErrorLogger().Printf("Unable to parse containerd config file: %v", err)
-		return nil
+		return empty
 	}
 	for _, ctd := range containerdConfig.Plugins {
 		ctd, ok := ctd.(map[string]interface{})["containerd"].(map[string]interface{})
@@ -122,13 +124,13 @@ func findAdditionalRuntimePlugins() iter.Seq[string] {
 			runtimes, ok := ctd["runtimes"].(map[string]interface{})
 			if ok {
 				for runtimeName := range runtimes {
-					logger.InfoLogger().Printf("Adding compatibility custom runtime %s configured in containerd config file %s", runtimeName, CONTAINERD_CONFIG_PATH)
+					logger.InfoLogger().Printf("Adding compatibility custom runtime %s configured in containerd config file %s", runtimeName, path)
 				}
 				return maps.Keys(runtimes)
 			}
 		}
 	}
-	return nil
+	return empty
 }
 
 // StopContainerdClient stops the container runtime client

--- a/go_node_engine/virtualization/Containers_test.go
+++ b/go_node_engine/virtualization/Containers_test.go
@@ -1,6 +1,8 @@
 package virtualization
 
 import (
+	"os"
+	"path/filepath"
 	"testing"
 
 	"gotest.tools/v3/assert"
@@ -34,4 +36,56 @@ func TestInstanceExtractionFromTaskidMultipleInstance(t *testing.T) {
 	taskid := genTaskID(sname, iid)
 	extracted := extractInstanceNumberFromTaskID(taskid)
 	assert.Equal(t, extracted, iid)
+}
+
+// Regression test for #512: ranging the result of findAdditionalRuntimePlugins
+// must not panic when the containerd config file is missing, empty, or fully
+// commented out (all top-level keys absent).
+func TestFindAdditionalRuntimePluginsHandlesEmptyConfig(t *testing.T) {
+	cases := map[string]string{
+		"empty file":         "",
+		"fully commented":    "# disabled_plugins = [\"cri\"]\n# [grpc]\n# address = \"/run/containerd/containerd.sock\"\n",
+		"no plugins section": "version = 2\n",
+	}
+	for name, contents := range cases {
+		t.Run(name, func(t *testing.T) {
+			dir := t.TempDir()
+			path := filepath.Join(dir, "config.toml")
+			assert.NilError(t, os.WriteFile(path, []byte(contents), 0o644))
+
+			count := 0
+			for range findAdditionalRuntimePluginsAt(path) {
+				count++
+			}
+			assert.Equal(t, count, 0)
+		})
+	}
+}
+
+func TestFindAdditionalRuntimePluginsHandlesMissingFile(t *testing.T) {
+	missing := filepath.Join(t.TempDir(), "does-not-exist.toml")
+	count := 0
+	for range findAdditionalRuntimePluginsAt(missing) {
+		count++
+	}
+	assert.Equal(t, count, 0)
+}
+
+func TestFindAdditionalRuntimePluginsReturnsConfiguredRuntimes(t *testing.T) {
+	dir := t.TempDir()
+	path := filepath.Join(dir, "config.toml")
+	contents := `version = 2
+[plugins."io.containerd.grpc.v1.cri".containerd.runtimes.runc]
+runtime_type = "io.containerd.runc.v2"
+[plugins."io.containerd.grpc.v1.cri".containerd.runtimes.kata]
+runtime_type = "io.containerd.kata.v2"
+`
+	assert.NilError(t, os.WriteFile(path, []byte(contents), 0o644))
+
+	got := map[string]bool{}
+	for name := range findAdditionalRuntimePluginsAt(path) {
+		got[name] = true
+	}
+	assert.Assert(t, got["runc"], "expected runc, got %v", got)
+	assert.Assert(t, got["kata"], "expected kata, got %v", got)
 }


### PR DESCRIPTION
Fixes #512.

`findAdditionalRuntimePlugins` returned `nil` (an untyped `iter.Seq[string]`) whenever the containerd config file was missing, unreadable, malformed, or fully commented out. The caller in `newContainerdRuntime` ranges over the result without a nil guard, and ranging over a nil `iter.Seq` panics — matching the stack trace in the issue:

```
panic: runtime error: invalid memory address or nil pointer dereference
go_node_engine/virtualization.newContainerdRuntime
  go_node_engine/virtualization/ContainersManagement.go:96
```

Verified locally: ranging over a `nil` `iter.Seq[string]` panics with `SIGSEGV`; ranging over `maps.Keys(map[string]interface{}{})` returns zero elements cleanly.

The fix returns an empty `iter.Seq` from every error/empty path and extracts a path-parameterised helper (`findAdditionalRuntimePluginsAt`) so the regression tests can exercise the behaviour with `t.TempDir()`.

Regression tests cover the three empty-config shapes from the issue (empty file, fully commented config, missing `plugins` section), a missing file, and a config that declares real runtimes.