### PR TITLE
feat: add log rotation configuration for nodeengine and netmanager

### DIFF
--- a/.github/workflows/node_engine_artifacts.yml
+++ b/.github/workflows/node_engine_artifacts.yml
@@ -29,7 +29,7 @@ jobs:
       - name: Package Artifacts
         run: |
           mkdir -p NodeEngine_folder_${{ matrix.architecture }}
-          cp NodeEngine nodeengined go_node_engine/build/install.sh go_node_engine/build/configure-gpu.sh go_node_engine/nodeengine.service NodeEngine_folder_${{ matrix.architecture }}
+          cp NodeEngine nodeengined go_node_engine/build/install.sh go_node_engine/build/configure-gpu.sh go_node_engine/nodeengine.service go_node_engine/oakestra.logrotate NodeEngine_folder_${{ matrix.architecture }}
           tar -czvf NodeEngine_${{ matrix.architecture }}.tar.gz -C NodeEngine_folder_${{ matrix.architecture }} .
 
       - name: Release Artifacts

--- a/go_node_engine/.gitignore
+++ b/go_node_engine/.gitignore
@@ -2,3 +2,5 @@
 bin/
 
 third_party/**/dist/
+
+!oakestra.logrotate

--- a/go_node_engine/build/install.sh
+++ b/go_node_engine/build/install.sh
@@ -70,11 +70,13 @@ else
     logrotate_src=""
 fi
 
+logrotate_status=0
 if [ -n "$logrotate_src" ]; then
     sudo cp "$logrotate_src" /etc/logrotate.d/oakestra
+    logrotate_status=$?
 fi
 
-if [ $? -eq 0 ]; then
+if [ $logrotate_status -eq 0 ]; then
   echo "Done, installation successful"
 else
   echo "Installation failed, errors reported!"

--- a/go_node_engine/build/install.sh
+++ b/go_node_engine/build/install.sh
@@ -17,6 +17,7 @@ if [ ! $? -eq 0 ]; then
 fi
 
 arch="$1"
+set -e
 
 #check containerd installation
 if sudo systemctl | grep -Fq 'containerd'; then
@@ -32,9 +33,9 @@ else
 fi
 
 #install latest version
-sudo mkdir /var/log/oakestra >/dev/null 2>&1
-sudo systemctl stop nodeengine >/dev/null 2>&1
-sudo systemctl stop netmanager >/dev/null 2>&1
+sudo mkdir -p /var/log/oakestra
+sudo systemctl stop nodeengine 2>/dev/null || true
+sudo systemctl stop netmanager 2>/dev/null || true
 
 #compatibility with build script
 if [ -e NodeEngine ]
@@ -56,7 +57,7 @@ else
     sudo cp ../nodeengine.service /etc/systemd/system/nodeengine.service
 fi  
 
-sudo systemctl daemon-reload >/dev/null 2>&1
+sudo systemctl daemon-reload
 
 sudo chmod 755 /bin/NodeEngine
 sudo chmod 755 /bin/nodeengined
@@ -70,15 +71,8 @@ else
     logrotate_src=""
 fi
 
-logrotate_status=0
 if [ -n "$logrotate_src" ]; then
-    sudo cp "$logrotate_src" /etc/logrotate.d/oakestra
-    logrotate_status=$?
+    sudo cp "$logrotate_src" /etc/logrotate.d/oakestra || echo "Warning: failed to install logrotate config — log rotation will not be configured"
 fi
 
-if [ $logrotate_status -eq 0 ]; then
-  echo "Done, installation successful"
-else
-  echo "Installation failed, errors reported!"
-  exit 1
-fi
+echo "Done, installation successful"

--- a/go_node_engine/build/install.sh
+++ b/go_node_engine/build/install.sh
@@ -61,6 +61,19 @@ sudo systemctl daemon-reload >/dev/null 2>&1
 sudo chmod 755 /bin/NodeEngine
 sudo chmod 755 /bin/nodeengined
 
+if [ -e oakestra.logrotate ]; then
+    logrotate_src="oakestra.logrotate"
+elif [ -e ../oakestra.logrotate ]; then
+    logrotate_src="../oakestra.logrotate"
+else
+    echo "Warning: oakestra.logrotate not found — log rotation will not be configured"
+    logrotate_src=""
+fi
+
+if [ -n "$logrotate_src" ]; then
+    sudo cp "$logrotate_src" /etc/logrotate.d/oakestra
+fi
+
 if [ $? -eq 0 ]; then
   echo "Done, installation successful"
 else

--- a/go_node_engine/oakestra.logrotate
+++ b/go_node_engine/oakestra.logrotate
@@ -2,7 +2,6 @@
     weekly
     rotate 4
     compress
-    delaycompress
     missingok
     notifempty
     copytruncate

--- a/go_node_engine/oakestra.logrotate
+++ b/go_node_engine/oakestra.logrotate
@@ -1,0 +1,9 @@
+/var/log/oakestra/*.log {
+    weekly
+    rotate 4
+    compress
+    delaycompress
+    missingok
+    notifempty
+    copytruncate
+}


### PR DESCRIPTION
Fixes #454 

Uses [logrotate](https://linux.die.net/man/8/logrotate) to fix the issues described inside the issue: 
- Add `/etc/logrotate.d/oakestra` during worker node installation to rotate `nodeengine.log` and `netmanager.log`
- Rotate weekly, keep 4 weeks of compressed archives, then delete automatically
- Warn (but don't fail) if oakestra.logrotate is missing during install
- Add .gitignore exception so oakestra.logrotate is not suppressed by the root *.log* rule