### PR TITLE
chore: update Node to v24 and job dependencies

### DIFF
--- a/.github/actions/awx-deploy/action.yml
+++ b/.github/actions/awx-deploy/action.yml
@@ -22,5 +22,5 @@ inputs:
     required: true
 
 runs:
-  using: "node16"
+  using: "node24"
   main: "index.js"

--- a/.github/actions/awx-deploy/index.js
+++ b/.github/actions/awx-deploy/index.js
@@ -1,16 +1,15 @@
-const core = require('@actions/core');
-const axios = require('axios');
-const https = require('https');
-const sslRootCAs = require('ssl-root-cas');
+import * as core from '@actions/core';
+import axios from 'axios';
+import https from 'https';
+import sslRootCAs from 'ssl-root-cas';
 
+https.globalAgent.options.ca = sslRootCAs.create();
+
+const POLL_INTERVAL_MS = 60_000;
+const TIMEOUT_MS = 2 * 60 * 60 * 1000; // 2 hours
 
 async function triggerAWX() {
   try {
-
-    // Add SSL root CAs to the global HTTPS agent
-    https.globalAgent.options.ca = sslRootCAs.create();
-
-
     const awxUrl = core.getInput('AWX_URL');
     const token = core.getInput('AWX_TOKEN');
     const workflowTemplateId = core.getInput('AWX_TEMPLATE_ID');
@@ -31,39 +30,38 @@ async function triggerAWX() {
       pr_fork_user: pullRequestUser
     };
 
-    // Print the URL, template ID, branch, and commit
-    console.log(`🌱 Branch: ${pullRequestBranch}`);
-    console.log(`#️⃣ Commit: ${pullRequestCommit}`);
-    console.log(`👷 PR Commit Author: ${pullRequestUser}`);
+    core.info(`🌱 Branch: ${pullRequestBranch}`);
+    core.info(`#️⃣ Commit: ${pullRequestCommit}`);
+    core.info(`👷 PR Commit Author: ${pullRequestUser}`);
 
     // Step 1: Trigger the workflow job template
     const jobLaunchUrl = `https://${awxUrl}/api/v2/workflow_job_templates/${workflowTemplateId}/launch/`;
     const response = await axios.post(jobLaunchUrl, { extra_vars: extraVars }, { headers });
 
-    const jobId = response.data.workflow_job;  // ID of the launched job
+    const jobId = response.data.workflow_job;
+    core.info(`🆔 Execution ID: ${jobId}`);
 
-    console.log(`🆔 Execution ID: ${jobId}`);
-
-    // Step 2: Poll the job status
+    // Step 2: Poll the job status until terminal state or timeout
     const jobStatusUrl = `https://${awxUrl}/api/v2/workflow_jobs/${jobId}/`;
-    let status = '';
+    const deadline = Date.now() + TIMEOUT_MS;
 
-    while (true) {
+    while (Date.now() < deadline) {
       const jobResponse = await axios.get(jobStatusUrl, { headers });
-      status = jobResponse.data.status;
+      const status = jobResponse.data.status;
 
-      console.log(`⚙️ Current job status: ${status} ⏳`);
+      core.info(`⚙️ Current job status: ${status} ⏳`);
 
       if (status === 'successful') {
-        console.log('🎉 ✅ 🎉  Tests passed successfully! 🎉 ✅ 🎉');
+        core.info('🎉 ✅ 🎉  Tests passed successfully! 🎉 ✅ 🎉');
         return;
       } else if (['failed', 'error', 'canceled'].includes(status)) {
         throw new Error(` 🔴 Tests execution failed with status: ${status} 🔴 `);
       }
 
-      // Wait for 1 minute before checking the status again
-      await new Promise(resolve => setTimeout(resolve, 60000));
+      await new Promise(resolve => setTimeout(resolve, POLL_INTERVAL_MS));
     }
+
+    throw new Error('Timed out waiting for AWX job to reach a terminal state');
 
   } catch (error) {
     core.setFailed(`Action failed: ${error.message}`);

--- a/.github/actions/awx-deploy/package.json
+++ b/.github/actions/awx-deploy/package.json
@@ -3,6 +3,7 @@
   "version": "1.0.0",
   "description": "Trigger AWX Oneshot Testbed for Oakestra Automated Testing",
   "main": "index.js",
+  "type": "module",
   "scripts": {
     "test": "echo \"Error: no test specified\" && exit 1"
   },
@@ -10,8 +11,7 @@
   "license": "MIT",
   "dependencies": {
     "axios": "^1.3.5",
-    "@actions/core": "^1.9.0",
+    "@actions/core": "^3.0.1",
     "ssl-root-cas": "^1.3.1"
-
   }
 }

--- a/.github/workflows/oneshot_testbed_workflow_run.yml
+++ b/.github/workflows/oneshot_testbed_workflow_run.yml
@@ -19,9 +19,9 @@ jobs:
       - name: Checkout
         uses: actions/checkout@v4
       - name: Set up Node.js
-        uses: actions/setup-node@v3
+        uses: actions/setup-node@v6
         with:
-          node-version: '16'
+          node-version: '24'
 
       - name: Install dependencies
         run: npm install


### PR DESCRIPTION
## Summary
Fixes the Oneshot pipeline failure caused by GitHub Actions runners switching to Node 24 by default on June 16th 2026 ([changelog](https://github.blog/changelog/2025-09-19-deprecation-of-node-20-on-github-actions-runners/)).

- Upgrade action runtime from `node16` to `node24` in `action.yml`
- Upgrade `actions/setup-node` from `v3` (Node 16) to `v6` (Node 24) in the workflow
- Convert `index.js` to ESM (`"type": "module"`, `import` syntax) required by `@actions/core` v3
- Upgrade `@actions/core` from `^1.9.0` to `^3.0.1` which adds Node 24 support
- Replace unbounded `while (true)` polling loop with a 2-hour deadline to prevent the action hanging indefinitely on a stuck AWX job
- Switch from `console.log` to `core.info` for idiomatic Actions output

## Related issue
Closes #545
