### PR TITLE
Allow longer task-ids for container instances

### DIFF
--- a/go_node_engine/virtualization/internal/containerd/ContainersManagement.go
+++ b/go_node_engine/virtualization/internal/containerd/ContainersManagement.go
@@ -2,6 +2,8 @@ package containerd
 
 import (
 	"context"
+	"crypto/sha256"
+	"encoding/base32"
 	"fmt"
 	"go_node_engine/csi"
 	"go_node_engine/logger"
@@ -15,6 +17,7 @@ import (
 	"maps"
 	"os"
 	"os/exec"
+	"regexp"
 	"sort"
 	"strconv"
 	"strings"
@@ -72,6 +75,8 @@ const CONTAINERD_CONFIG_PATH = "/etc/containerd/config.toml"
 
 // Max container cleanup duration
 const CLEANUP_TIMEOUT = 5 * time.Second
+
+const TASK_ID_LABEL = "io.oakestra.taskid"
 
 // GetContainerdRuntime returns the container runtime client
 func newContainerdRuntime(_ virtrt.RuntimeInfo) virtrt.Runtime {
@@ -365,10 +370,12 @@ func (r *ContainerRuntime) containerCreationRoutine(
 	// -- add oci SpecOpts to containerOpts
 	containerOpts = append(containerOpts, ctd.WithNewSpec(specOpts...))
 
+	containerOpts = append(containerOpts, containerd.WithAdditionalContainerLabels(map[string]string{TASK_ID_LABEL: taskid}))
+
 	// Create the container
 	container, err := r.containerClient.NewContainer(
 		ctx,
-		taskId,
+		convertTaskIdToContainerId(taskId),
 		containerOpts...,
 	)
 	if err != nil {
@@ -412,6 +419,9 @@ func (r *ContainerRuntime) containerCreationRoutine(
 	// if Overlay mode is active then attach network to the task
 	if model.GetNodeInfo().Overlay {
 		taskpid := int(task.Pid())
+		// In the network attachment code path below, we don't need to implement any special handling
+		// for the container ID, even though it's different from taskId, because of convertTaskIdToContainerId.
+		// That is, because the network attachment is pid-based (via taskpid param).
 		err = requests.AttachNetworkToTask(taskpid, service.Sname, service.Instance, service.Ports)
 		if err != nil {
 			logger.ErrorLogger().Printf("Unable to attach network interface to the task: %v", err)
@@ -559,6 +569,12 @@ func (r *ContainerRuntime) ResourceMonitoring(every time.Duration, notifyHandler
 				continue
 			}
 
+			taskId, ok := containerMetadata.Labels[TASK_ID_LABEL]
+			if !ok {
+				logger.WarnLogger().Printf("Unable to fetch task id for container %s", container.ID())
+				continue
+			}
+
 			currentsnapshotter := r.containerClient.SnapshotService(containerMetadata.Snapshotter)
 			usage, err := currentsnapshotter.Usage(r.ctx, containerMetadata.SnapshotKey)
 			if err != nil {
@@ -569,11 +585,11 @@ func (r *ContainerRuntime) ResourceMonitoring(every time.Duration, notifyHandler
 				Cpu:      fmt.Sprintf("%f", cpuUsage),
 				Memory:   fmt.Sprintf("%f", memUsage),
 				Disk:     fmt.Sprintf("%d", usage.Size),
-				Sname:    taskid.ExtractServiceName(container.ID()),
+				Sname:    taskid.extractSnameFromTaskID(taskId),
 				Runtime:  string(model.CONTAINER_RUNTIME),
-				Logs:     logutils.GetLogs(container.ID()),
-				Instance: taskid.ExtractInstanceNumber(container.ID()),
-				Status:   r.taskStatus(task),
+				Logs:     logutils.GetLogs(taskId),
+				Instance: taskid.ExtractInstanceNumber(taskId),
+                Status:   r.taskStatus(task),
 			})
 		}
 		resourceList = append(resourceList, model.InstantiatingResources(model.CONTAINER_RUNTIME)...)
@@ -767,6 +783,35 @@ func killTask(ctx context.Context, task ctd.Task, container ctd.Container) error
 
 	logger.ErrorLogger().Printf("Task %s terminated", task.ID())
 	return nil
+}
+
+const containerIdMaxLen = 72
+
+var containerIdHashEncoding = base32.NewEncoding("abcdefghijklmnopqrstuvwxyz234567").WithPadding(base32.NoPadding)
+var invalidContainerIdChars = regexp.MustCompile("[^a-zA-Z0-9._-]")
+
+// convertTaskIdToContainerId converts the given taskId of an instance to an ID that can be used to containerd container.
+// The following requirements are fulfilled by the resulting container id:
+//   - The maximum length for container ids is 76 characters (see https://github.com/containerd/containerd/blob/main/pkg/identifiers/validate.go).
+//   - Machine names can only contain characters matching this regex "[A-Za-z0-9]" or "[._-]" (inverse in invalidContainerIdChars).
+//     To make sure this requirement is fulfilled, other characters are not taken over from the taskId.
+//   - For more consistency in unit names, all uppercase characters in the taskId are converted to lowercase
+//     when taken over into the result.
+//   - To ensure generated container IDs are still unique after all the steps taken above,
+//     part of the base-32 encoded hash of the original taskId is appended to the result as ".${hash}".
+func convertTaskIdToContainerId(taskId string) string {
+	hashBytes := sha256.Sum256([]byte(taskId))
+	hashString := containerIdHashEncoding.EncodeToString(hashBytes[:])
+	// At this point hashString is 52 characters long which is too long to be useful, so we truncate it.
+	// This should still make collisions very unlikely.
+	hashString = hashString[:20]
+
+	containerIdSuffix := "." + hashString
+
+	safeTaskId := strings.ToLower(invalidContainerIdChars.ReplaceAllString(taskId, ""))
+	safeTaskId = safeTaskId[:min(containerIdMaxLen-len(containerIdSuffix), len(safeTaskId))]
+
+	return safeTaskId + containerIdSuffix
 }
 
 // gpuInfo holds GPU device information for sorting

--- a/go_node_engine/virtualization/internal/containerd/ContainersManagement.go
+++ b/go_node_engine/virtualization/internal/containerd/ContainersManagement.go
@@ -589,7 +589,7 @@ func (r *ContainerRuntime) ResourceMonitoring(every time.Duration, notifyHandler
 				Runtime:  string(model.CONTAINER_RUNTIME),
 				Logs:     logutils.GetLogs(taskId),
 				Instance: taskid.ExtractInstanceNumber(taskId),
-                Status:   r.taskStatus(task),
+				Status:   r.taskStatus(task),
 			})
 		}
 		resourceList = append(resourceList, model.InstantiatingResources(model.CONTAINER_RUNTIME)...)

--- a/go_node_engine/virtualization/internal/containerd/ContainersManagement.go
+++ b/go_node_engine/virtualization/internal/containerd/ContainersManagement.go
@@ -370,7 +370,7 @@ func (r *ContainerRuntime) containerCreationRoutine(
 	// -- add oci SpecOpts to containerOpts
 	containerOpts = append(containerOpts, ctd.WithNewSpec(specOpts...))
 
-	containerOpts = append(containerOpts, containerd.WithAdditionalContainerLabels(map[string]string{TASK_ID_LABEL: taskid}))
+	containerOpts = append(containerOpts, ctd.WithAdditionalContainerLabels(map[string]string{TASK_ID_LABEL: taskId}))
 
 	// Create the container
 	container, err := r.containerClient.NewContainer(
@@ -585,7 +585,7 @@ func (r *ContainerRuntime) ResourceMonitoring(every time.Duration, notifyHandler
 				Cpu:      fmt.Sprintf("%f", cpuUsage),
 				Memory:   fmt.Sprintf("%f", memUsage),
 				Disk:     fmt.Sprintf("%d", usage.Size),
-				Sname:    taskid.extractSnameFromTaskID(taskId),
+				Sname:    taskid.ExtractServiceName(taskId),
 				Runtime:  string(model.CONTAINER_RUNTIME),
 				Logs:     logutils.GetLogs(taskId),
 				Instance: taskid.ExtractInstanceNumber(taskId),

--- a/go_node_engine/virtualization/internal/containerd/ContainersManagement.go
+++ b/go_node_engine/virtualization/internal/containerd/ContainersManagement.go
@@ -793,7 +793,7 @@ var invalidContainerIdChars = regexp.MustCompile("[^a-zA-Z0-9._-]")
 // convertTaskIdToContainerId converts the given taskId of an instance to an ID that can be used to containerd container.
 // The following requirements are fulfilled by the resulting container id:
 //   - The maximum length for container ids is 76 characters (see https://github.com/containerd/containerd/blob/main/pkg/identifiers/validate.go).
-//   - Machine names can only contain characters matching this regex "[A-Za-z0-9]" or "[._-]" (inverse in invalidContainerIdChars).
+//   - Container IDs can only contain characters matching this regex "[A-Za-z0-9]" or "[._-]" (inverse in invalidContainerIdChars).
 //     To make sure this requirement is fulfilled, other characters are not taken over from the taskId.
 //   - For more consistency in unit names, all uppercase characters in the taskId are converted to lowercase
 //     when taken over into the result.

--- a/go_node_engine/virtualization/internal/containerd/ContainersManagement.go
+++ b/go_node_engine/virtualization/internal/containerd/ContainersManagement.go
@@ -785,33 +785,56 @@ func killTask(ctx context.Context, task ctd.Task, container ctd.Container) error
 	return nil
 }
 
-const containerIdMaxLen = 72
+const containerIdMaxLen = 76
 
-var containerIdHashEncoding = base32.NewEncoding("abcdefghijklmnopqrstuvwxyz234567").WithPadding(base32.NoPadding)
-var invalidContainerIdChars = regexp.MustCompile("[^a-zA-Z0-9._-]")
+var (
+	containerIdHashEncoding = base32.NewEncoding(
+		"abcdefghijklmnopqrstuvwxyz234567",
+	).WithPadding(base32.NoPadding)
 
-// convertTaskIdToContainerId converts the given taskId of an instance to an ID that can be used to containerd container.
-// The following requirements are fulfilled by the resulting container id:
-//   - The maximum length for container ids is 76 characters (see https://github.com/containerd/containerd/blob/main/pkg/identifiers/validate.go).
-//   - Container IDs can only contain characters matching this regex "[A-Za-z0-9]" or "[._-]" (inverse in invalidContainerIdChars).
-//     To make sure this requirement is fulfilled, other characters are not taken over from the taskId.
-//   - For more consistency in unit names, all uppercase characters in the taskId are converted to lowercase
-//     when taken over into the result.
-//   - To ensure generated container IDs are still unique after all the steps taken above,
-//     part of the base-32 encoded hash of the original taskId is appended to the result as ".${hash}".
+	invalidContainerIdChars = regexp.MustCompile(`[^a-zA-Z0-9._-]`)
+	containerIdSeparators   = regexp.MustCompile(`[._-]+`)
+)
+
+// convertTaskIdToContainerId converts taskId into a valid containerd identifier.
+// See // See https://github.com/containerd/containerd/blob/v1.7.28/identifiers/validate.go.
+// The generated identifier:
+//   - is at most 76 characters long;
+//   - contains only ASCII letters, digits, dots, underscores, and hyphens;
+//   - starts and ends with an ASCII letter or digit;
+//   - contains no consecutive separators;
+//   - uses lowercase characters in its readable prefix; and
+//   - includes a 100-bit base32-encoded prefix of the SHA-256 hash of the
+//     original task ID to make collisions unlikely.
+//
+// Invalid characters are removed and runs of separators are normalized to a
+// single dot. If no readable prefix remains, the hash alone is returned.
 func convertTaskIdToContainerId(taskId string) string {
 	hashBytes := sha256.Sum256([]byte(taskId))
-	hashString := containerIdHashEncoding.EncodeToString(hashBytes[:])
 	// At this point hashString is 52 characters long which is too long to be useful, so we truncate it.
 	// This should still make collisions very unlikely.
-	hashString = hashString[:20]
+	hashString := containerIdHashEncoding.EncodeToString(hashBytes[:])[:20]
 
-	containerIdSuffix := "." + hashString
+	safeTaskId := strings.ToLower(
+		invalidContainerIdChars.ReplaceAllString(taskId, ""),
+	)
+	safeTaskId = containerIdSeparators.ReplaceAllString(safeTaskId, ".")
+	safeTaskId = strings.Trim(safeTaskId, "._-")
 
-	safeTaskId := strings.ToLower(invalidContainerIdChars.ReplaceAllString(taskId, ""))
-	safeTaskId = safeTaskId[:min(containerIdMaxLen-len(containerIdSuffix), len(safeTaskId))]
+	maxPrefixLen := containerIdMaxLen - len(hashString) - 1
+	if len(safeTaskId) > maxPrefixLen {
+		safeTaskId = safeTaskId[:maxPrefixLen]
+	}
 
-	return safeTaskId + containerIdSuffix
+	// Truncation may leave a separator at the end of the readable prefix.
+	safeTaskId = strings.TrimRight(safeTaskId, "._-")
+
+	// This ensures the container id doesn't end up being '.<hash>' which would be an illegal start with a separator.
+	if safeTaskId == "" {
+		return hashString
+	}
+
+	return safeTaskId + "." + hashString
 }
 
 // gpuInfo holds GPU device information for sorting

--- a/go_node_engine/virtualization/internal/containerd/Containers_test.go
+++ b/go_node_engine/virtualization/internal/containerd/Containers_test.go
@@ -1,10 +1,14 @@
 package containerd
 
 import (
+	"crypto/sha256"
+	"encoding/base32"
 	"os"
 	"path/filepath"
+	"strings"
 	"testing"
 
+	containerdidentifiers "github.com/containerd/containerd/identifiers"
 	"gotest.tools/v3/assert"
 )
 
@@ -58,4 +62,243 @@ runtime_type = "io.containerd.kata.v2"
 	}
 	assert.Assert(t, got["runc"], "expected runc, got %v", got)
 	assert.Assert(t, got["kata"], "expected kata, got %v", got)
+}
+
+func expectedContainerIdHash(taskId string) string {
+	encoding := base32.NewEncoding(
+		"abcdefghijklmnopqrstuvwxyz234567",
+	).WithPadding(base32.NoPadding)
+
+	hashBytes := sha256.Sum256([]byte(taskId))
+	return encoding.EncodeToString(hashBytes[:])[:20]
+}
+
+func TestConvertTaskIdToContainerId(t *testing.T) {
+	truncatesAtSeparator := strings.Repeat("a", 54) +
+		"-" + strings.Repeat("b", 20)
+
+	tests := []struct {
+		name       string
+		taskId     string
+		wantPrefix string
+	}{
+		{
+			name:       "ordinary identifier",
+			taskId:     "task-01",
+			wantPrefix: "task.01",
+		},
+		{
+			name:       "uppercase characters",
+			taskId:     "Task_ID",
+			wantPrefix: "task.id",
+		},
+		{
+			name:       "repeated dots",
+			taskId:     "foo..bar",
+			wantPrefix: "foo.bar",
+		},
+		{
+			name:       "mixed consecutive separators",
+			taskId:     "foo._-bar",
+			wantPrefix: "foo.bar",
+		},
+		{
+			name:       "leading separators",
+			taskId:     ".-_foo",
+			wantPrefix: "foo",
+		},
+		{
+			name:       "trailing separators",
+			taskId:     "foo_-.",
+			wantPrefix: "foo",
+		},
+		{
+			name:       "leading trailing and repeated separators",
+			taskId:     ".-_Foo_01_-. ",
+			wantPrefix: "foo.01",
+		},
+		{
+			name:       "invalid characters removed",
+			taskId:     "foo/@bar",
+			wantPrefix: "foobar",
+		},
+		{
+			name:       "unicode characters removed",
+			taskId:     "Täst-🔥ID",
+			wantPrefix: "tst.id",
+		},
+		{
+			name:       "maximum readable prefix",
+			taskId:     strings.Repeat("a", 55),
+			wantPrefix: strings.Repeat("a", 55),
+		},
+		{
+			name:       "long readable prefix truncated",
+			taskId:     strings.Repeat("a", 100),
+			wantPrefix: strings.Repeat("a", 55),
+		},
+		{
+			name:       "truncation lands on separator",
+			taskId:     truncatesAtSeparator,
+			wantPrefix: strings.Repeat("a", 54),
+		},
+		{
+			name:       "only separators",
+			taskId:     "._-",
+			wantPrefix: "",
+		},
+		{
+			name:       "only invalid characters",
+			taskId:     "🔥///",
+			wantPrefix: "",
+		},
+		{
+			name:       "empty task ID",
+			taskId:     "",
+			wantPrefix: "",
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			got := convertTaskIdToContainerId(tt.taskId)
+
+			want := expectedContainerIdHash(tt.taskId)
+			if tt.wantPrefix != "" {
+				want = tt.wantPrefix + "." + want
+			}
+
+			if got != want {
+				t.Fatalf(
+					"convertTaskIdToContainerId(%q) = %q; want %q",
+					tt.taskId,
+					got,
+					want,
+				)
+			}
+
+			if len(got) > containerIdMaxLen {
+				t.Errorf(
+					"generated ID is %d bytes; maximum is %d",
+					len(got),
+					containerIdMaxLen,
+				)
+			}
+
+			if err := containerdidentifiers.Validate(got); err != nil {
+				t.Errorf(
+					"generated ID %q is rejected by containerd: %v",
+					got,
+					err,
+				)
+			}
+		})
+	}
+}
+
+func TestConvertTaskIdToContainerIdIsDeterministic(t *testing.T) {
+	const taskId = "Task._-with/invalid🔥characters"
+
+	first := convertTaskIdToContainerId(taskId)
+	second := convertTaskIdToContainerId(taskId)
+
+	if first != second {
+		t.Fatalf(
+			"conversion is not deterministic: first %q, second %q",
+			first,
+			second,
+		)
+	}
+}
+
+func TestConvertTaskIdToContainerIdHashDistinguishesNormalizedInputs(
+	t *testing.T,
+) {
+	tests := []struct {
+		name   string
+		first  string
+		second string
+	}{
+		{
+			name:   "repeated separator",
+			first:  "foo..bar",
+			second: "foo.bar",
+		},
+		{
+			name:   "uppercase",
+			first:  "FOO",
+			second: "foo",
+		},
+		{
+			name:   "invalid characters",
+			first:  "foo/@bar",
+			second: "foobar",
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			first := convertTaskIdToContainerId(tt.first)
+			second := convertTaskIdToContainerId(tt.second)
+
+			if first == second {
+				t.Fatalf(
+					"different task IDs %q and %q generated the same ID %q",
+					tt.first,
+					tt.second,
+					first,
+				)
+			}
+		})
+	}
+}
+
+func FuzzConvertTaskIdToContainerId(f *testing.F) {
+	seeds := []string{
+		"",
+		"task",
+		"Task_ID",
+		"foo..bar",
+		".-_foo_01_-.",
+		"🔥///",
+		strings.Repeat("a", 100),
+		strings.Repeat("a", 54) + "-" + strings.Repeat("b", 20),
+	}
+
+	for _, seed := range seeds {
+		f.Add(seed)
+	}
+
+	f.Fuzz(func(t *testing.T, taskId string) {
+		got := convertTaskIdToContainerId(taskId)
+
+		if got == "" {
+			t.Fatal("generated an empty container ID")
+		}
+
+		if len(got) > containerIdMaxLen {
+			t.Fatalf(
+				"generated ID %q is %d bytes; maximum is %d",
+				got,
+				len(got),
+				containerIdMaxLen,
+			)
+		}
+
+		if err := containerdidentifiers.Validate(got); err != nil {
+			t.Fatalf(
+				"generated ID %q is rejected by containerd: %v",
+				got,
+				err,
+			)
+		}
+
+		if second := convertTaskIdToContainerId(taskId); second != got {
+			t.Fatalf(
+				"conversion is not deterministic: first %q, second %q",
+				got,
+				second,
+			)
+		}
+	})
 }

--- a/go_node_engine/virtualization/internal/logutils/logutils.go
+++ b/go_node_engine/virtualization/internal/logutils/logutils.go
@@ -10,9 +10,9 @@ import (
 const LOG_SIZE = 1024
 
 // reads the last 100 bytes of the logfile of a container
-func GetLogs(serviceID string) string {
+func GetLogs(taskId string) string {
 
-	file, err := os.Open(fmt.Sprintf("%s/%s", model.GetNodeInfo().LogDirectory, serviceID))
+	file, err := os.Open(fmt.Sprintf("%s/%s", model.GetNodeInfo().LogDirectory, taskId))
 	if err != nil {
 		logger.ErrorLogger().Printf("%v", err)
 		return ""

--- a/root_orchestrator/system-manager-python/sla/schema.py
+++ b/root_orchestrator/system-manager-python/sla/schema.py
@@ -9,8 +9,8 @@ sla_schema = {
                 "type": "object",
                 "properties": {
                     "applicationID": {"type": "string"},  # was integer
-                    "application_name": {"type": "string", "pattern": "^[a-zA-Z0-9]{1,30}$"},
-                    "application_namespace": {"type": "string", "pattern": "^[a-zA-Z0-9]{1,30}$"},
+                    "application_name": {"type": "string", "pattern": "^[a-zA-Z0-9]{1,32}$"},
+                    "application_namespace": {"type": "string", "pattern": "^[a-zA-Z0-9]{1,32}$"},
                     "application_desc": {"type": "string"},
                     "microservices": {
                         "type": "array",
@@ -23,11 +23,11 @@ sla_schema = {
                                 },  # disabling this for now
                                 "microservice_name": {
                                     "type": "string",
-                                    "pattern": "^[a-zA-Z0-9]{1,30}$",
+                                    "pattern": "^[a-zA-Z0-9]{1,32}$",
                                 },
                                 "microservice_namespace": {
                                     "type": "string",
-                                    "pattern": "^[a-zA-Z0-9]{1,30}$",
+                                    "pattern": "^[a-zA-Z0-9]{1,32}$",
                                 },
                                 "virtualization": {"type": "string"},
                                 "volumes": {


### PR DESCRIPTION
Fixes #307 by instead of using the task-id of a Job directly as container id, truncating and appending a hash to it before passing it to containerd.  