### PR TITLE
Exempt protobuf from linter

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -2,7 +2,8 @@
 line-length = 100
 exclude = [
     ".github/*",
-    "**/proto",
+    "**/*_pb2.py",
+    "**/*_pb2_grpc.py",
 ]
 [tool.ruff.lint]
 extend-select = [


### PR DESCRIPTION
Exempt protobuf files from linter as these are automatically generated.