### PR TITLE
Fix root_orchestrator/system-manager-python requirements.txt protobuf…

### DIFF
--- a/root_orchestrator/system-manager-python/requirements.txt
+++ b/root_orchestrator/system-manager-python/requirements.txt
@@ -20,7 +20,7 @@ flask_swagger_ui
 mongomock==4.1.2
 grpcio~=1.75.1
 grpcio-tools~=1.75.1
-protobuf~=4.25.2
+protobuf>=4.25.2,<7.0.0
 git+https://github.com/oakestra/oakestra.git@${LIB_BRANCH}#subdirectory=libraries/resource_abstractor_client
 git+https://github.com/oakestra/oakestra.git@${LIB_BRANCH}#subdirectory=libraries/oakestra_utils_library
 cryptography==44.0.1


### PR DESCRIPTION
… pin

Loosen protobuf~=4.25.2 to protobuf>=4.25.2,<7.0.0 to resolve ResolutionImpossible Docker build errors caused by grpcio-tools 1.75.1 requiring protobuf>=6.31.1.

Co-Authored-By: Mistral Vibe <vibe@mistral.ai>

Generated by Mistral Vibe.