### PR TITLE
fix: pin ruff version and align with pre-commit

### DIFF
--- a/.github/workflows/python_codestyle_check.yml
+++ b/.github/workflows/python_codestyle_check.yml
@@ -6,12 +6,14 @@ jobs:
   style-check:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v3
+      - uses: actions/checkout@v7
       - name: Run ruff formating check
-        uses: astral-sh/ruff-action@v3
+        uses: astral-sh/ruff-action@v4.1.0
         with:
+          version: 0.15.22
           args: format --check
       - name: Run ruff linting check
-        uses: astral-sh/ruff-action@v3
+        uses: astral-sh/ruff-action@v4.1.0
         with:
+          version: 0.15.22
           args: check

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -29,8 +29,12 @@ repos:
       pass_filenames: false
       always_run: true
 - repo: https://github.com/astral-sh/ruff-pre-commit
-  rev: v0.14.2
+  rev: v0.15.22
   hooks:
     - id: ruff-check
       stages: [pre-commit]
       files: \.py$
+    - id: ruff-format
+      stages: [pre-commit]
+      files: \.py$
+      args: [--check]


### PR DESCRIPTION
## Pin ruff version and align pre-commit with CI

Pre-commit and CI were running different ruff checks (pre-commit lacked a
format check, and CI had no pinned version), so code could pass locally and
still fail in CI.

- Add `ruff-format --check` to pre-commit (was lint-only before)
- Pin ruff to `0.15.22` in both pre-commit and CI