### PR TITLE
chore: migrate loggers to log/slog

### DIFF
--- a/go_node_engine/NodeEngine.go
+++ b/go_node_engine/NodeEngine.go
@@ -7,6 +7,6 @@ import (
 
 func main() {
 	if err := cmd.Execute(); err != nil {
-		logger.ErrorLogger().Printf("NodeEngine error executing: %v", err)
+		logger.ErrorLogger("NodeEngine error executing: %v", err)
 	}
 }

--- a/go_node_engine/addons/flops/FLOps.go
+++ b/go_node_engine/addons/flops/FLOps.go
@@ -9,7 +9,7 @@ import (
 type FlopsAddon struct{}
 
 func (a FlopsAddon) Startup(configFile []string) {
-	logger.InfoLogger().Printf("Starting FLOps Data Manager")
+	logger.InfoLogger("Starting FLOps Data Manager")
 	HandleFLOpsDataManager()
 }
 
@@ -20,7 +20,7 @@ func HandleFLOpsDataManager() {
 	cmd := exec.Command("docker", "ps", "-a", "--format", "{{.Names}}")
 	output, err := cmd.Output()
 	if err != nil {
-		logger.ErrorLogger().Fatalln("Error:", err)
+		logger.FatalErrorLogger("Error:", err)
 		return
 	}
 
@@ -41,7 +41,7 @@ func HandleFLOpsDataManager() {
 		err := cmd.Run()
 
 		if err != nil {
-			logger.ErrorLogger().Fatalf("Error pulling FLOps Data Manager image: %v\n", err)
+			logger.FatalErrorLogger("Error pulling FLOps Data Manager image: %v\n", err)
 			return
 		}
 
@@ -49,13 +49,13 @@ func HandleFLOpsDataManager() {
 		err = cmd.Run()
 
 		if err != nil {
-			logger.ErrorLogger().Fatalf("Error running container: %v\n", err)
+			logger.FatalErrorLogger("Error running container: %v\n", err)
 			return
 		}
 
 	} else {
-		logger.InfoLogger().Printf("Container %q already exists.", container_name)
+		logger.InfoLogger("Container %q already exists.", container_name)
 	}
 
-	logger.InfoLogger().Printf("FLOps Data Manager container started successfully.")
+	logger.InfoLogger("FLOps Data Manager container started successfully.")
 }

--- a/go_node_engine/cmd/conf.go
+++ b/go_node_engine/cmd/conf.go
@@ -426,7 +426,7 @@ func setBuilder(trigger string) error {
 	cmd := exec.Command("dpkg", "-s", "qemu-user-static")
 	output, err := cmd.Output()
 	if err != nil || !strings.Contains(string(output), "ok installed") {
-		logger.ErrorLogger().Fatalf("Unable to find qemu-user-static apt package for multi-platform image-builder: %v\n", err)
+		logger.FatalErrorLogger("Unable to find qemu-user-static apt package for multi-platform image-builder: %v\n", err)
 	}
 
 	active := trigger == "on" || trigger == "enable" || trigger == "true"

--- a/go_node_engine/cmd/logs.go
+++ b/go_node_engine/cmd/logs.go
@@ -34,7 +34,7 @@ func logsNodeEngine() error {
 	defer func() {
 		err := logFile.Close()
 		if err != nil {
-			logger.ErrorLogger().Printf("Unable to close logfile")
+			logger.ErrorLogger("Unable to close logfile")
 		}
 	}()
 

--- a/go_node_engine/cmd/root.go
+++ b/go_node_engine/cmd/root.go
@@ -114,7 +114,7 @@ func attach() error {
 	defer func() {
 		err := logFile.Close()
 		if err != nil {
-			logger.ErrorLogger().Printf("Unable to close logfile")
+			logger.ErrorLogger("Unable to close logfile")
 		}
 	}()
 

--- a/go_node_engine/cmd/stop.go
+++ b/go_node_engine/cmd/stop.go
@@ -33,7 +33,7 @@ func stopNodeEngine() {
 
 	err := cmd.Run()
 	if err != nil {
-		logger.ErrorLogger().Printf("%v", err)
+		logger.ErrorLogger("%v", err)
 	}
 
 	if stderr.Len() > 0 {
@@ -45,6 +45,6 @@ func stopNodeEngine() {
 	cmd = exec.Command("systemctl", "stop", "netmanager", "--no-pager")
 	err = cmd.Run()
 	if err != nil {
-		logger.ErrorLogger().Printf("%v", err)
+		logger.ErrorLogger("%v", err)
 	}
 }

--- a/go_node_engine/config/config.go
+++ b/go_node_engine/config/config.go
@@ -144,7 +144,7 @@ func GetConfFileManager() ConfFileManager {
 func (c *ConfFile) Get() (ConfFile, error) {
 	data, err := os.ReadFile(confPath)
 	if errors.Is(err, os.ErrNotExist) || (err == nil && len(data) == 0) {
-		logger.InfoLogger().Printf("Config file missing or empty, using default configuration")
+		logger.InfoLogger("Config file missing or empty, using default configuration")
 		def := GenDefaultConfig()
 		return def, c.Write(def)
 	}
@@ -154,7 +154,7 @@ func (c *ConfFile) Get() (ConfFile, error) {
 
 	var clusterConf ConfFile
 	if err := json.Unmarshal(data, &clusterConf); err != nil {
-		logger.ErrorLogger().Printf("Error reading configuration: %v, resetting the file\n", err)
+		logger.ErrorLogger("Error reading configuration: %v, resetting the file\n", err)
 		if resetErr := c.Write(GenDefaultConfig()); resetErr != nil {
 			return *c, resetErr
 		}
@@ -169,7 +169,7 @@ func (c *ConfFile) Write(new ConfFile) error {
 		return err
 	}
 	if err := os.MkdirAll(confDir, 0755); err != nil {
-		logger.ErrorLogger().Printf("Failed to create config directory %s: %v\n", confDir, err)
+		logger.ErrorLogger("Failed to create config directory %s: %v\n", confDir, err)
 		return err
 	}
 	return os.WriteFile(confPath, data, 0644)

--- a/go_node_engine/csi/csi_manager.go
+++ b/go_node_engine/csi/csi_manager.go
@@ -49,7 +49,7 @@ func MountVolumes(service model.Service) ([]MountedVolume, error) {
 func UnmountVolumes(mounted []MountedVolume) {
 	for _, mv := range mounted {
 		if err := unmountSingle(mv); err != nil {
-			logger.ErrorLogger().Printf("[CSI] Unmount error for volume %s: %v", mv.VolumeID, err)
+			logger.ErrorLogger("[CSI] Unmount error for volume %s: %v", mv.VolumeID, err)
 		}
 	}
 }
@@ -90,7 +90,7 @@ func mountSingle(service model.Service, vol model.VolumeRequest) (MountedVolume,
 			return MountedVolume{}, fmt.Errorf("NodeStageVolume: %w", err)
 		}
 		mv.StagingPath = stagingPath
-		logger.InfoLogger().Printf("[CSI] Staged volume %s at %s", vol.VolumeID, stagingPath)
+		logger.InfoLogger("[CSI] Staged volume %s at %s", vol.VolumeID, stagingPath)
 	}
 
 	// Publish
@@ -110,7 +110,7 @@ func mountSingle(service model.Service, vol model.VolumeRequest) (MountedVolume,
 		return mv, fmt.Errorf("NodePublishVolume: %w", err)
 	}
 	mv.TargetPath = targetPath
-	logger.InfoLogger().Printf("[CSI] Published volume %s at %s", vol.VolumeID, targetPath)
+	logger.InfoLogger("[CSI] Published volume %s at %s", vol.VolumeID, targetPath)
 
 	return mv, nil
 }
@@ -119,7 +119,7 @@ func unmountSingle(mv MountedVolume) error {
 	reg := GetRegistry()
 	plugin, err := reg.Get(mv.DriverName)
 	if err != nil {
-		logger.ErrorLogger().Printf("[CSI] Plugin %s not found during unmount of %s: %v",
+		logger.ErrorLogger("[CSI] Plugin %s not found during unmount of %s: %v",
 			mv.DriverName, mv.VolumeID, err)
 		return nil
 	}
@@ -134,9 +134,9 @@ func unmountSingle(mv MountedVolume) error {
 			TargetPath: mv.TargetPath,
 		})
 		if err != nil {
-			logger.ErrorLogger().Printf("[CSI] NodeUnpublishVolume %s: %v", mv.VolumeID, err)
+			logger.ErrorLogger("[CSI] NodeUnpublishVolume %s: %v", mv.VolumeID, err)
 		} else {
-			logger.InfoLogger().Printf("[CSI] Unpublished volume %s from %s", mv.VolumeID, mv.TargetPath)
+			logger.InfoLogger("[CSI] Unpublished volume %s from %s", mv.VolumeID, mv.TargetPath)
 		}
 		_ = os.Remove(mv.TargetPath)
 	}
@@ -148,9 +148,9 @@ func unmountSingle(mv MountedVolume) error {
 			StagingTargetPath: mv.StagingPath,
 		})
 		if err != nil {
-			logger.ErrorLogger().Printf("[CSI] NodeUnstageVolume %s: %v", mv.VolumeID, err)
+			logger.ErrorLogger("[CSI] NodeUnstageVolume %s: %v", mv.VolumeID, err)
 		} else {
-			logger.InfoLogger().Printf("[CSI] Unstaged volume %s from %s", mv.VolumeID, mv.StagingPath)
+			logger.InfoLogger("[CSI] Unstaged volume %s from %s", mv.VolumeID, mv.StagingPath)
 		}
 		_ = os.Remove(mv.StagingPath)
 	}

--- a/go_node_engine/csi/csi_registry.go
+++ b/go_node_engine/csi/csi_registry.go
@@ -73,7 +73,7 @@ func GetRegistry() *Registry {
 func (r *Registry) InitFromConfig(conf config.ConfFile) {
 	for _, driverConf := range conf.CSIDrivers {
 		if err := r.Register(driverConf); err != nil {
-			logger.ErrorLogger().Printf("[CSI] Failed to register plugin %q (%s): %v",
+			logger.ErrorLogger("[CSI] Failed to register plugin %q (%s): %v",
 				driverConf.Name, driverConf.Endpoint, err)
 		}
 	}
@@ -82,7 +82,7 @@ func (r *Registry) InitFromConfig(conf config.ConfFile) {
 // Register probes a single CSI plugin endpoint and, on success, adds it to the
 // registry.
 func (r *Registry) Register(cfg config.CSIDriverType) error {
-	logger.InfoLogger().Printf("[CSI] Probing plugin at %s", cfg.Endpoint)
+	logger.InfoLogger("[CSI] Probing plugin at %s", cfg.Endpoint)
 
 	conn, err := dialPlugin(cfg.Endpoint)
 	if err != nil {
@@ -114,7 +114,7 @@ func (r *Registry) Register(cfg config.CSIDriverType) error {
 	}
 	p.DriverName = info.GetName()
 	p.DriverVersion = info.GetVendorVersion()
-	logger.InfoLogger().Printf("[CSI] Plugin info: name=%s version=%s", p.DriverName, p.DriverVersion)
+	logger.InfoLogger("[CSI] Plugin info: name=%s version=%s", p.DriverName, p.DriverVersion)
 
 	// Use discovered name if config did not specify one
 	if cfg.Name == "" {
@@ -131,7 +131,7 @@ func (r *Registry) Register(cfg config.CSIDriverType) error {
 	for _, cap := range capsResp.GetCapabilities() {
 		if cap.GetRpc().GetType() == csipb.NodeServiceCapability_RPC_STAGE_UNSTAGE_VOLUME {
 			p.StageUnstageRequired = true
-			logger.InfoLogger().Printf("[CSI] Plugin %s requires STAGE_UNSTAGE_VOLUME", p.DriverName)
+			logger.InfoLogger("[CSI] Plugin %s requires STAGE_UNSTAGE_VOLUME", p.DriverName)
 		}
 	}
 
@@ -139,7 +139,7 @@ func (r *Registry) Register(cfg config.CSIDriverType) error {
 	r.plugins[p.DriverName] = p
 	r.mu.Unlock()
 
-	logger.InfoLogger().Printf("[CSI] Plugin %s registered (stageUnstage=%v)",
+	logger.InfoLogger("[CSI] Plugin %s registered (stageUnstage=%v)",
 		p.DriverName, p.StageUnstageRequired)
 	return nil
 }
@@ -171,7 +171,7 @@ func (r *Registry) StopAll() {
 	r.mu.Lock()
 	defer r.mu.Unlock()
 	for name, p := range r.plugins {
-		logger.InfoLogger().Printf("[CSI] Closing connection to plugin %s", name)
+		logger.InfoLogger("[CSI] Closing connection to plugin %s", name)
 		p.Close()
 	}
 	r.plugins = make(map[string]*Plugin)

--- a/go_node_engine/internal/daemon/nodeengined.go
+++ b/go_node_engine/internal/daemon/nodeengined.go
@@ -37,7 +37,7 @@ func main() {
 	var err error
 	configs, err = configManager.Get()
 	if err != nil {
-		logger.ErrorLogger().Fatal(err)
+		logger.FatalErrorLogger("%v", err)
 	}
 
 	// set log directory
@@ -49,7 +49,7 @@ func main() {
 	// Initialize virtualization runtimes
 	runtimeManager, err := virtualization.NewRuntimeManager()
 	if err != nil {
-		logger.ErrorLogger().Fatal(err)
+		logger.FatalErrorLogger("%v", err)
 	}
 	for _, virt := range configs.Virtualizations {
 		if virt.Active {
@@ -65,14 +65,14 @@ func main() {
 	csiReg.InitFromConfig(configs)
 	for _, driver := range csiReg.List() {
 		model.GetNodeInfo().AddCSIDriver(driver)
-		logger.InfoLogger().Printf("CSI driver available: %s (%s)", driver.Name, driver.Endpoint)
+		logger.InfoLogger("CSI driver available: %s (%s)", driver.Name, driver.Endpoint)
 	}
 	defer csiReg.StopAll()
 
 	//Startup Addons
 	for _, addon := range configs.Addons {
 		if addon.Active {
-			logger.InfoLogger().Printf("Startup addon: %s", addon.Name)
+			logger.InfoLogger("Startup addon: %s", addon.Name)
 			addons.StartupAddon(model.AddonType(addon.Name), addon.Config)
 		}
 	}
@@ -83,29 +83,29 @@ func main() {
 	// enable overlay network if required
 	switch configs.OverlayNetwork {
 	case config.AUTO_OAK_NETWORK:
-		logger.InfoLogger().Printf("Looking for local NetManager socket.")
+		logger.InfoLogger("Looking for local NetManager socket.")
 		cmd := exec.Command("systemctl", "start", "netmanager")
 		_ = cmd.Run()
 		model.EnableOverlay()
 	case cmd.DISABLE_NETWORK:
-		logger.InfoLogger().Printf("Overlay network disabled 🟠")
+		logger.InfoLogger("Overlay network disabled 🟠")
 	default:
 		if strings.Contains(configs.OverlayNetwork, "custom:") {
 			netPath := strings.Split(configs.OverlayNetwork, ":")
 			model.GetNodeInfo().SetOverlaySocket(netPath[1])
 			model.EnableOverlay()
 		} else {
-			logger.InfoLogger().Printf("Invalid overlay network detected. Network disabled 🟠")
+			logger.InfoLogger("Invalid overlay network detected. Network disabled 🟠")
 		}
 	}
 	if model.GetNodeInfo().Overlay {
-		logger.InfoLogger().Printf("Overlay network enabled 🟢")
+		logger.InfoLogger("Overlay network enabled 🟢")
 		// wait for systemctl to start the netmanager service
-		logger.InfoLogger().Printf("Waiting for NetManager to start...")
+		logger.InfoLogger("Waiting for NetManager to start...")
 		time.Sleep(5 * time.Second)
 		err := requests.RegisterSelfToNetworkComponent()
 		if err != nil {
-			logger.ErrorLogger().Fatalf("Error registering to NetManager: %v", err)
+			logger.FatalErrorLogger("Error registering to NetManager: %v", err)
 		}
 	}
 
@@ -121,20 +121,20 @@ func main() {
 	termination := make(chan os.Signal, 1)
 	signal.Notify(termination, syscall.SIGTERM, syscall.SIGINT)
 	ossignal := <-termination
-	logger.InfoLogger().Printf("Terminating the NodeEngine, signal:%v", ossignal)
+	logger.InfoLogger("Terminating the NodeEngine, signal:%v", ossignal)
 }
 
 func clusterHandshake() requests.HandshakeAnswer {
-	logger.InfoLogger().Printf("INIT: Starting handshake with cluster orchestrator %s:%d", configs.ClusterAddress, configs.ClusterPort)
+	logger.InfoLogger("INIT: Starting handshake with cluster orchestrator %s:%d", configs.ClusterAddress, configs.ClusterPort)
 	node := model.GetNodeInfo()
-	logger.InfoLogger().Printf("Node Statistics: \n__________________")
-	logger.InfoLogger().Printf("CPU Cores: %d", node.CpuCores)
-	logger.InfoLogger().Printf("CPU Usage: %f", node.CpuUsage)
-	logger.InfoLogger().Printf("Mem Usage: %f", node.MemoryUsed)
-	logger.InfoLogger().Printf("GPU Driver: %s", node.GpuDriver)
-	logger.InfoLogger().Printf("\n________________")
+	logger.InfoLogger("Node Statistics: \n__________________")
+	logger.InfoLogger("CPU Cores: %d", node.CpuCores)
+	logger.InfoLogger("CPU Usage: %f", node.CpuUsage)
+	logger.InfoLogger("Mem Usage: %f", node.MemoryUsed)
+	logger.InfoLogger("GPU Driver: %s", node.GpuDriver)
+	logger.InfoLogger("\n________________")
 	clusterReponse := requests.ClusterHandshake(configs.ClusterAddress, configs.ClusterPort)
-	logger.InfoLogger().Printf("Got cluster response with MQTT port %s and node ID %s", clusterReponse.MqttPort, clusterReponse.NodeId)
+	logger.InfoLogger("Got cluster response with MQTT port %s and node ID %s", clusterReponse.MqttPort, clusterReponse.NodeId)
 
 	model.SetNodeId(clusterReponse.NodeId)
 	return clusterReponse

--- a/go_node_engine/logger/logger.go
+++ b/go_node_engine/logger/logger.go
@@ -1,38 +1,33 @@
 package logger
 
 import (
-	"log"
+	"fmt"
+	"log/slog"
 	"os"
-	"sync"
 )
 
-var infologger *log.Logger
-var errorlogger *log.Logger
-var warnlogger *log.Logger
-var infoonce sync.Once
-var erroronce sync.Once
-var warnonce sync.Once
-
-// InfoLogger returns a logger for info messages
-func InfoLogger() *log.Logger {
-	infoonce.Do(func() {
-		infologger = log.New(os.Stdout, "INFO-", log.Ldate|log.Ltime|log.Lshortfile)
-	})
-	return infologger
+// InfoLogger logs an info level message with the given format and arguments
+func InfoLogger(format string, args ...any) {
+	slog.Info(fmt.Sprintf(format, args...))
 }
 
-// WarnLogger returns a logger for warn messages
-func WarnLogger() *log.Logger {
-	warnonce.Do(func() {
-		warnlogger = log.New(os.Stderr, "WARN-", log.Ldate|log.Ltime|log.Lshortfile)
-	})
-	return warnlogger
+// WarnLogger logs a warning level message with the given format and arguments
+func WarnLogger(format string, args ...any) {
+	slog.Warn(fmt.Sprintf(format, args...))
 }
 
-// ErrorLogger returns a logger for error messages
-func ErrorLogger() *log.Logger {
-	erroronce.Do(func() {
-		errorlogger = log.New(os.Stderr, "ERROR-", log.Ldate|log.Ltime|log.Lshortfile)
-	})
-	return errorlogger
+// ErrorLogger logs an error level message with the given format and arguments
+func ErrorLogger(format string, args ...any) {
+	slog.Error(fmt.Sprintf(format, args...))
+}
+
+// DebugLogger logs a debug level message with the given format and arguments
+func DebugLogger(format string, args ...any) {
+	slog.Debug(fmt.Sprintf(format, args...))
+}
+
+// FatalErrorLogger logs an error level message and exits with status code 1
+func FatalErrorLogger(format string, args ...any) {
+	slog.Error(fmt.Sprintf(format, args...))
+	os.Exit(1)
 }

--- a/go_node_engine/logger/logger_test.go
+++ b/go_node_engine/logger/logger_test.go
@@ -1,0 +1,83 @@
+package logger
+
+import (
+	"bytes"
+	"log/slog"
+	"os"
+	"os/exec"
+	"strings"
+	"testing"
+)
+
+// TestFatalErrorLogger_LogsAndExits verifies that FatalErrorLogger
+// logs an error message and exits with status code 1.
+func TestFatalErrorLogger_LogsAndExits(t *testing.T) {
+	// FatalErrorLogger calls os.Exit(1), so we need to test it in a subprocess
+	if os.Getenv("TEST_FATAL") == "1" {
+		// This is the subprocess - call FatalErrorLogger and exit
+		FatalErrorLogger("test fatal message: %s", "arg")
+		return
+	}
+
+	// Run in a subprocess to capture exit code
+	cmd := exec.Command(os.Args[0], "-test.run=TestFatalErrorLogger_LogsAndExits")
+	cmd.Env = append(os.Environ(), "TEST_FATAL=1")
+
+	var stderr bytes.Buffer
+	cmd.Stderr = &stderr
+
+	err := cmd.Run()
+
+	// Verify exit code is 1
+	exitErr, ok := err.(*exec.ExitError)
+	if !ok {
+		t.Fatalf("Expected exit error, got %v", err)
+	}
+	if exitErr.ExitCode() != 1 {
+		t.Errorf("Expected exit code 1, got %d", exitErr.ExitCode())
+	}
+
+	// Verify error message was logged
+	output := stderr.String()
+	if !strings.Contains(output, "test fatal message: arg") {
+		t.Errorf("Expected log message in stderr, got: %s", output)
+	}
+}
+
+// TestLoggerFunctions tests that all logger functions work without panicking
+func TestLoggerFunctions(t *testing.T) {
+	// Capture output to verify it works
+	var buf bytes.Buffer
+	original := slog.Default().Handler()
+
+	// Create a test logger that writes to our buffer
+	testHandler := slog.NewTextHandler(&buf, &slog.HandlerOptions{Level: slog.LevelDebug})
+	testLogger := slog.New(testHandler)
+
+	// Temporarily replace the default logger
+	// Note: This affects global state, but it's okay for tests
+	// We'll restore it after
+	slog.SetDefault(testLogger)
+	defer slog.SetDefault(slog.New(original))
+
+	// Test all functions - they should not panic
+	InfoLogger("info test: %s", "arg1")
+	WarnLogger("warn test: %s", "arg2")
+	ErrorLogger("error test: %s", "arg3")
+	DebugLogger("debug test: %s", "arg4")
+
+	// Verify output contains our messages
+	output := buf.String()
+	if !strings.Contains(output, "info test: arg1") {
+		t.Errorf("Expected info message in output")
+	}
+	if !strings.Contains(output, "warn test: arg2") {
+		t.Errorf("Expected warn message in output")
+	}
+	if !strings.Contains(output, "error test: arg3") {
+		t.Errorf("Expected error message in output")
+	}
+	if !strings.Contains(output, "debug test: arg4") {
+		t.Errorf("Expected debug message in output")
+	}
+}

--- a/go_node_engine/model/Node.go
+++ b/go_node_engine/model/Node.go
@@ -159,7 +159,7 @@ func SetNodeId(id string) {
 func getIp() string {
 	conf, err := config.GetConfFileManager().Get()
 	if err != nil {
-		logger.ErrorLogger().Fatal(err)
+		logger.FatalErrorLogger("%v", err)
 	}
 	if conf.PublicIp.IsAuto() {
 
@@ -172,7 +172,7 @@ func getIp() string {
 
 		req, err := http.Get("https://ifconfig.co")
 		if err != nil {
-			logger.ErrorLogger().Printf("%v", err.Error())
+			logger.ErrorLogger("%v", err.Error())
 			return getPrivateIp()
 		}
 		if req.Body == nil {
@@ -181,13 +181,13 @@ func getIp() string {
 		defer func(Body io.ReadCloser) {
 			err := Body.Close()
 			if err != nil {
-				logger.ErrorLogger().Printf("%v", err.Error())
+				logger.ErrorLogger("%v", err.Error())
 			}
 		}(req.Body)
 
 		body, err := io.ReadAll(req.Body)
 		if err != nil {
-			logger.ErrorLogger().Printf("%v", err.Error())
+			logger.ErrorLogger("%v", err.Error())
 			return getPrivateIp()
 		}
 
@@ -225,7 +225,7 @@ func getHostname() string {
 	hostname, err := os.Hostname()
 	if err != nil {
 		hostname = ""
-		logger.ErrorLogger().Fatal("Unable to get Node hostname")
+		logger.FatalErrorLogger("Unable to get Node hostname")
 	}
 	return hostname
 }
@@ -233,7 +233,7 @@ func getHostname() string {
 func getSystemInfo() map[string]string {
 	hostinfo, err := host.Info()
 	if err != nil {
-		logger.ErrorLogger().Printf("Error: %s", err.Error())
+		logger.ErrorLogger("Error: %s", err.Error())
 		return make(map[string]string, 0)
 	}
 	sysInfo := make(map[string]string)
@@ -249,7 +249,7 @@ func getSystemInfo() map[string]string {
 func getCpuCores() int {
 	cpu, err := cpu.Counts(true)
 	if err != nil {
-		logger.ErrorLogger().Printf("Error: %s", err.Error())
+		logger.ErrorLogger("Error: %s", err.Error())
 		return 0
 	}
 	return cpu
@@ -269,7 +269,7 @@ func getAvgCpuUsage() float64 {
 func getMemoryMB() int {
 	mem, err := mem.VirtualMemory()
 	if err != nil {
-		logger.ErrorLogger().Printf("Error: %s", err.Error())
+		logger.ErrorLogger("Error: %s", err.Error())
 		return 0
 	}
 	return int(mem.Available >> 20)
@@ -278,7 +278,7 @@ func getMemoryMB() int {
 func getMemoryUsage() float64 {
 	mem, err := mem.VirtualMemory()
 	if err != nil {
-		logger.ErrorLogger().Printf("Error: %s", err.Error())
+		logger.ErrorLogger("Error: %s", err.Error())
 		return 100
 	}
 	return mem.UsedPercent

--- a/go_node_engine/mqtt/MqttClient.go
+++ b/go_node_engine/mqtt/MqttClient.go
@@ -22,11 +22,11 @@ var brokerUrl = ""
 var brokerPort = ""
 
 var messagePubHandler mqtt.MessageHandler = func(client mqtt.Client, msg mqtt.Message) {
-	logger.InfoLogger().Printf("DEBUG - Received message: %s from topic: %s\n", msg.Payload(), msg.Topic())
+	logger.InfoLogger("DEBUG - Received message: %s from topic: %s\n", msg.Payload(), msg.Topic())
 }
 
 var connectHandler mqtt.OnConnectHandler = func(client mqtt.Client) {
-	logger.InfoLogger().Println("Connected to the MQTT broker")
+	logger.InfoLogger("Connected to the MQTT broker")
 
 	topicsQosMap := make(map[string]byte)
 	for key := range TOPICS {
@@ -36,7 +36,7 @@ var connectHandler mqtt.OnConnectHandler = func(client mqtt.Client) {
 	//subscribe to all the topics
 	tqtoken := client.SubscribeMultiple(topicsQosMap, subscribeHandlerDispatcher)
 	tqtoken.Wait()
-	logger.InfoLogger().Printf("Subscribed to topics \n")
+	logger.InfoLogger("Subscribed to topics \n")
 
 }
 
@@ -49,7 +49,7 @@ var subscribeHandlerDispatcher = func(client mqtt.Client, msg mqtt.Message) {
 }
 
 var connectLostHandler mqtt.ConnectionLostHandler = func(client mqtt.Client, err error) {
-	logger.InfoLogger().Printf("Connect lost: %v", err)
+	logger.InfoLogger("Connect lost: %v", err)
 }
 
 // InitMqtt initializes the mqtt client by connecting to the broker, setting the client ID and the topics
@@ -63,7 +63,7 @@ func InitMqtt(
 ) {
 
 	if clientID != "" {
-		logger.InfoLogger().Printf("Mqtt already initialized no need for any further initialization")
+		logger.InfoLogger("Mqtt already initialized no need for any further initialization")
 		return
 	}
 
@@ -86,10 +86,10 @@ func InitMqtt(
 	opts.OnConnectionLost = connectLostHandler
 
 	if certFile != "" {
-		logger.InfoLogger().Printf("MQTT - Configuring TLS")
+		logger.InfoLogger("MQTT - Configuring TLS")
 		cert, err := tls.LoadX509KeyPair(certFile, keyFile)
 		if err != nil {
-			logger.ErrorLogger().Printf("Error loading certificate: %v", err)
+			logger.ErrorLogger("Error loading certificate: %v", err)
 		}
 		opts.SetTLSConfig(&tls.Config{
 			Certificates: []tls.Certificate{cert},
@@ -108,10 +108,10 @@ func runMqttClient(opts *mqtt.ClientOptions) {
 }
 
 func publishToBroker(topic string, payload string) {
-	logger.InfoLogger().Printf("MQTT - publish to - %s - the payload - %s", topic, payload)
+	logger.InfoLogger("MQTT - publish to - %s - the payload - %s", topic, payload)
 	token := mainMqttClient.Publish(fmt.Sprintf("nodes/%s/%s", clientID, topic), 1, false, payload)
 	if token.WaitTimeout(time.Second*5) && token.Error() != nil {
-		logger.ErrorLogger().Printf("ERROR: MQTT PUBLISH: %s", token.Error())
+		logger.ErrorLogger("ERROR: MQTT PUBLISH: %s", token.Error())
 	}
 }
 
@@ -125,12 +125,12 @@ func withRuntimeManager(
 }
 
 func deployHandler(client mqtt.Client, msg mqtt.Message, runtimeManager *virtualization.RuntimeManager) {
-	logger.InfoLogger().Printf("Received deployment request with payload: %s", string(msg.Payload()))
+	logger.InfoLogger("Received deployment request with payload: %s", string(msg.Payload()))
 	service := model.Service{}
 	err := json.Unmarshal(msg.Payload(), &service)
-	logger.InfoLogger().Printf("%+v", service)
+	logger.InfoLogger("%+v", service)
 	if err != nil {
-		logger.ErrorLogger().Printf("ERROR: unable to unmarshal cluster orch request: %v", err)
+		logger.ErrorLogger("ERROR: unable to unmarshal cluster orch request: %v", err)
 		return
 	}
 	//handle deployment in background
@@ -139,7 +139,7 @@ func deployHandler(client mqtt.Client, msg mqtt.Message, runtimeManager *virtual
 		err = runtime.Deploy(service, ReportServiceStatus)
 		service.Status = model.SERVICE_CREATED
 		if err != nil {
-			logger.ErrorLogger().Printf("ERROR during app deployment: %v", err)
+			logger.ErrorLogger("ERROR during app deployment: %v", err)
 			service.StatusDetail = err.Error()
 			service.Status = model.SERVICE_FAILED
 		}
@@ -148,18 +148,18 @@ func deployHandler(client mqtt.Client, msg mqtt.Message, runtimeManager *virtual
 }
 
 func deleteHandler(client mqtt.Client, msg mqtt.Message, runtimeManager *virtualization.RuntimeManager) {
-	logger.InfoLogger().Printf("Received undeployment request with payload: %s", string(msg.Payload()))
+	logger.InfoLogger("Received undeployment request with payload: %s", string(msg.Payload()))
 	service := model.Service{}
 	err := json.Unmarshal(msg.Payload(), &service)
 	if err != nil {
-		logger.ErrorLogger().Printf("ERROR: unable to unmarshal cluster orch request: %v", err)
+		logger.ErrorLogger("ERROR: unable to unmarshal cluster orch request: %v", err)
 		return
 	}
 	go func() {
 		runtime := runtimeManager.GetRuntime(model.RuntimeType(service.Runtime))
 		err = runtime.Undeploy(service.Sname, service.Instance)
 		if err != nil {
-			logger.ErrorLogger().Printf("Unable to undeploy application: %s", err.Error())
+			logger.ErrorLogger("Unable to undeploy application: %s", err.Error())
 			return
 		}
 		service.Status = model.SERVICE_UNDEPLOYED
@@ -185,7 +185,7 @@ func ReportServiceStatus(service model.Service) {
 	}
 	jsonmsg, err := json.Marshal(reportStatusStruct)
 	if err != nil {
-		logger.ErrorLogger().Printf("ERROR: unable to report service status: %v", err)
+		logger.ErrorLogger("ERROR: unable to report service status: %v", err)
 	}
 	publishToBroker("job", string(jsonmsg))
 }
@@ -200,7 +200,7 @@ func ReportServiceResources(services []model.Resources) {
 	}
 	jsonmsg, err := json.Marshal(reportStatusStruct)
 	if err != nil {
-		logger.ErrorLogger().Printf("ERROR: unable to report services resources: %v", err)
+		logger.ErrorLogger("ERROR: unable to report services resources: %v", err)
 	}
 	publishToBroker("jobs/resources", string(jsonmsg))
 }
@@ -209,7 +209,7 @@ func ReportServiceResources(services []model.Resources) {
 func ReportNodeInformation(node model.Node) {
 	data, err := json.Marshal(node)
 	if err != nil {
-		logger.ErrorLogger().Printf("ERROR: error gathering node info")
+		logger.ErrorLogger("ERROR: error gathering node info")
 	}
 	publishToBroker("information", string(data))
 }

--- a/go_node_engine/requests/ClusterManagerRequests.go
+++ b/go_node_engine/requests/ClusterManagerRequests.go
@@ -21,13 +21,13 @@ type HandshakeAnswer struct {
 func ClusterHandshake(address string, port int) HandshakeAnswer {
 	data, err := json.Marshal(model.GetNodeInfo())
 	if err != nil {
-		logger.ErrorLogger().Fatalf("Handshake failed, json encoding problem, %v", err)
+		logger.FatalErrorLogger("Handshake failed, json encoding problem, %v", err)
 	}
 	jsonbody := bytes.NewBuffer(data)
 
 	cfg, err := config.GetConfFileManager().Get()
 	if err != nil {
-		logger.ErrorLogger().Fatalf("Could not get config")
+		logger.FatalErrorLogger("Could not get config")
 	}
 
 	var resp *http.Response
@@ -38,26 +38,26 @@ func ClusterHandshake(address string, port int) HandshakeAnswer {
 	resp, err = http.Post(fmt.Sprintf("%s://%s:%d/api/node/register", proto, address, port), "application/json", jsonbody)
 
 	if err != nil {
-		logger.ErrorLogger().Fatalf("Handshake failed, %v", err)
+		logger.FatalErrorLogger("Handshake failed, %v", err)
 	}
 	if resp.StatusCode != 200 {
-		logger.ErrorLogger().Fatalf("Handshake failed with error code %d", resp.StatusCode)
+		logger.FatalErrorLogger("Handshake failed with error code %d", resp.StatusCode)
 	}
 	//defer resp.Body.Close()
 	defer func() {
 		if err := resp.Body.Close(); err != nil {
-			logger.ErrorLogger().Fatalf("Handshake failed, %v", err)
+			logger.FatalErrorLogger("Handshake failed, %v", err)
 		}
 	}()
 
 	handhsakeanswer := HandshakeAnswer{}
 	responseBytes, err := io.ReadAll(resp.Body)
 	if err != nil {
-		logger.ErrorLogger().Fatalf("Handshake failed, %v", err)
+		logger.FatalErrorLogger("Handshake failed, %v", err)
 	}
 	err = json.Unmarshal(responseBytes, &handhsakeanswer)
 	if err != nil {
-		logger.ErrorLogger().Fatalf("Handshake failed, %v", err)
+		logger.FatalErrorLogger("Handshake failed, %v", err)
 	}
 	return handhsakeanswer
 }

--- a/go_node_engine/util/iotools/close.go
+++ b/go_node_engine/util/iotools/close.go
@@ -7,6 +7,6 @@ import (
 
 func CloseOrWarn(closer io.Closer, name string) {
 	if err := closer.Close(); err != nil {
-		logger.WarnLogger().Printf("failed to close %q: %v", name, err)
+		logger.WarnLogger("failed to close %q: %v", name, err)
 	}
 }

--- a/go_node_engine/util/iotools/remove.go
+++ b/go_node_engine/util/iotools/remove.go
@@ -12,7 +12,7 @@ func RemoveOrWarn(name string) {
 
 func RemoveOrWarnInFs(fs afero.Fs, name string) {
 	if err := fs.Remove(name); err != nil {
-		logger.WarnLogger().Printf("failed to remove file or directory %q: %v", name, err)
+		logger.WarnLogger("failed to remove file or directory %q: %v", name, err)
 	}
 }
 
@@ -22,6 +22,6 @@ func RemoveAllOrWarn(name string) {
 
 func RemoveAllOrWarnInFs(fs afero.Fs, name string) {
 	if err := fs.RemoveAll(name); err != nil {
-		logger.WarnLogger().Printf("failed to remove file or directory %q: %v", name, err)
+		logger.WarnLogger("failed to remove file or directory %q: %v", name, err)
 	}
 }

--- a/go_node_engine/virtualization/internal/containerd/ContainersManagement.go
+++ b/go_node_engine/virtualization/internal/containerd/ContainersManagement.go
@@ -77,7 +77,7 @@ const CLEANUP_TIMEOUT = 5 * time.Second
 func newContainerdRuntime(_ virtrt.RuntimeInfo) virtrt.Runtime {
 	client, err := ctd.New("/run/containerd/containerd.sock")
 	if err != nil {
-		logger.ErrorLogger().Printf("Unable to start the container engine: %v\n", err)
+		logger.ErrorLogger("Unable to start the container engine: %v\n", err)
 		return &ContainerRuntime{}
 	}
 
@@ -98,7 +98,7 @@ func newContainerdRuntime(_ virtrt.RuntimeInfo) virtrt.Runtime {
 		found = true
 	}
 	if !found {
-		logger.WarnLogger().Printf("No additional OCI runtimes found in containerd config %s. This worker will use the default runc runtime.", CONTAINERD_CONFIG_PATH)
+		logger.WarnLogger("No additional OCI runtimes found in containerd config %s. This worker will use the default runc runtime.", CONTAINERD_CONFIG_PATH)
 	}
 
 	return &runtime
@@ -118,14 +118,14 @@ func findAdditionalRuntimePluginsAt(configPath string) iter.Seq[string] {
 	emptyIterator := func(yield func(string) bool) {}
 	data, err := os.ReadFile(configPath)
 	if err != nil {
-		logger.ErrorLogger().Printf("Unable to read containerd config file: %v", err)
+		logger.ErrorLogger("Unable to read containerd config file: %v", err)
 		return emptyIterator
 	}
 	var containerdConfig struct {
 		Plugins map[string]interface{} `toml:"plugins"`
 	}
 	if err := toml.Unmarshal(data, &containerdConfig); err != nil {
-		logger.ErrorLogger().Printf("Unable to parse containerd config file: %v", err)
+		logger.ErrorLogger("Unable to parse containerd config file: %v", err)
 		return emptyIterator
 	}
 	for _, ctdPlugin := range containerdConfig.Plugins {
@@ -134,13 +134,13 @@ func findAdditionalRuntimePluginsAt(configPath string) iter.Seq[string] {
 			runtimes, ok := ctdPluginInner["runtimes"].(map[string]interface{})
 			if ok {
 				for runtimeName := range runtimes {
-					logger.InfoLogger().Printf("Adding compatibility custom runtime %s configured in containerd config file %s", runtimeName, configPath)
+					logger.InfoLogger("Adding compatibility custom runtime %s configured in containerd config file %s", runtimeName, configPath)
 				}
 				return maps.Keys(runtimes)
 			}
 		}
 	}
-	logger.WarnLogger().Printf("No OCI runtimes found in containerd config %s. This worker will use the default runc runtime.", configPath)
+	logger.WarnLogger("No OCI runtimes found in containerd config %s. This worker will use the default runc runtime.", configPath)
 	return emptyIterator
 }
 
@@ -156,7 +156,7 @@ func (r *ContainerRuntime) Stop() {
 	for _, taskId := range taskIDs {
 		err := r.Undeploy(taskid.ExtractServiceName(taskId), taskid.ExtractInstanceNumber(taskId))
 		if err != nil {
-			logger.ErrorLogger().Printf("Unable to undeploy %s, error: %v", taskId, err)
+			logger.ErrorLogger("Unable to undeploy %s, error: %v", taskId, err)
 		}
 	}
 	waitDone := make(chan struct{})
@@ -166,13 +166,13 @@ func (r *ContainerRuntime) Stop() {
 	}()
 	select {
 	case <-waitDone:
-		logger.InfoLogger().Printf("All containers stopped cleanly")
+		logger.InfoLogger("All containers stopped cleanly")
 	case <-time.After(CLEANUP_TIMEOUT):
-		logger.ErrorLogger().Printf("Timed out waiting for containers to stop, forcing cleanup")
+		logger.ErrorLogger("Timed out waiting for containers to stop, forcing cleanup")
 		r.forceContainerCleanup()
 	}
 	if err := r.containerClient.Close(); err != nil {
-		logger.ErrorLogger().Printf("Unable to close containerd client: %v", err)
+		logger.ErrorLogger("Unable to close containerd client: %v", err)
 	}
 }
 
@@ -185,7 +185,7 @@ func (r *ContainerRuntime) Deploy(service model.Service, statusChangeNotificatio
 	if err == nil {
 		image = ctd.NewImage(r.containerClient, sysimg)
 	} else {
-		logger.ErrorLogger().Printf("Error retrieving the image: %v \n Trying to pull the image online.", err)
+		logger.ErrorLogger("Error retrieving the image: %v \n Trying to pull the image online.", err)
 
 		remoteOpt := []ctd.RemoteOpt{ctd.WithPullUnpack}
 		if service.Platform != "" {
@@ -261,7 +261,7 @@ func (r *ContainerRuntime) Undeploy(service string, instance int) error {
 		*ch <- true
 		return nil
 	}
-	logger.ErrorLogger().Printf("Unable to undeploy service %s instance %d: not found", service, instance)
+	logger.ErrorLogger("Unable to undeploy service %s instance %d: not found", service, instance)
 	return fmt.Errorf("service not found")
 }
 
@@ -298,9 +298,9 @@ func (r *ContainerRuntime) containerCreationRoutine(
 			containerOpts = append(containerOpts, ctd.WithRuntime(service.Runtime, &runcoptions.Options{}))
 		} else {
 			path, err := exec.LookPath(service.Runtime)
-			logger.InfoLogger().Printf("Using custom runtime %s", path)
+			logger.InfoLogger("Using custom runtime %s", path)
 			if err != nil {
-				logger.ErrorLogger().Printf("ERROR: unable to find runtime %s, %v", service.Runtime, err)
+				logger.ErrorLogger("ERROR: unable to find runtime %s, %v", service.Runtime, err)
 			}
 			containerOpts = append(containerOpts, ctd.WithRuntime(plugin.RuntimeRuncV2, &runcoptions.Options{BinaryName: path}))
 		}
@@ -328,13 +328,13 @@ func (r *ContainerRuntime) containerCreationRoutine(
 	if service.Vgpus > 0 {
 		gpuDevices, err := selectBestGPUs(service.Vgpus)
 		if err != nil {
-			logger.ErrorLogger().Printf("Failed to select GPUs: %v", err)
+			logger.ErrorLogger("Failed to select GPUs: %v", err)
 			// Fallback to GPU 0 if selection fails
 			specOpts = append(specOpts, nvidia.WithGPUs(nvidia.WithDevices(0), nvidia.WithAllCapabilities))
-			logger.InfoLogger().Printf("NVIDIA - Adding GPU 0 (fallback)")
+			logger.InfoLogger("NVIDIA - Adding GPU 0 (fallback)")
 		} else {
 			specOpts = append(specOpts, nvidia.WithGPUs(nvidia.WithDevices(gpuDevices...), nvidia.WithAllCapabilities))
-			logger.InfoLogger().Printf("NVIDIA - Adding GPU(s): %v", gpuDevices)
+			logger.InfoLogger("NVIDIA - Adding GPU(s): %v", gpuDevices)
 		}
 	}
 	// ---- mount CSI volumes (stage + publish) and add bind mounts to OCI spec
@@ -385,14 +385,14 @@ func (r *ContainerRuntime) containerCreationRoutine(
 	//defer file.Close()
 	defer func() {
 		if err := file.Close(); err != nil {
-			logger.ErrorLogger().Printf("Unable to close log file: %v", err)
+			logger.ErrorLogger("Unable to close log file: %v", err)
 		}
 	}()
 
 	task, err := container.NewTask(ctx, cio.NewCreator(cio.WithStreams(nil, file, file)))
 
 	if err != nil {
-		logger.ErrorLogger().Printf("ERROR: containerd task creation failure: %v", err)
+		logger.ErrorLogger("ERROR: containerd task creation failure: %v", err)
 		_ = container.Delete(ctx)
 		revert(err)
 		return
@@ -404,7 +404,7 @@ func (r *ContainerRuntime) containerCreationRoutine(
 	// get wait channel
 	exitStatusC, err := task.Wait(ctx)
 	if err != nil {
-		logger.ErrorLogger().Printf("ERROR: containerd task wait failure: %v", err)
+		logger.ErrorLogger("ERROR: containerd task wait failure: %v", err)
 		revert(err)
 		return
 	}
@@ -414,7 +414,7 @@ func (r *ContainerRuntime) containerCreationRoutine(
 		taskpid := int(task.Pid())
 		err = requests.AttachNetworkToTask(taskpid, service.Sname, service.Instance, service.Ports)
 		if err != nil {
-			logger.ErrorLogger().Printf("Unable to attach network interface to the task: %v", err)
+			logger.ErrorLogger("Unable to attach network interface to the task: %v", err)
 			revert(err)
 			return
 		}
@@ -422,7 +422,7 @@ func (r *ContainerRuntime) containerCreationRoutine(
 
 	// execute the image's task
 	if err := task.Start(ctx); err != nil {
-		logger.ErrorLogger().Printf("ERROR: containerd task start failure: %v", err)
+		logger.ErrorLogger("ERROR: containerd task start failure: %v", err)
 		revert(err)
 		return
 	}
@@ -480,7 +480,7 @@ func getTotalCpuUsageByPid(pid int32) (float64, error) {
 	totCpu := 0.0
 	procs, err := process.NewProcess(pid)
 	if err != nil {
-		logger.ErrorLogger().Printf("ERROR: %v", err)
+		logger.ErrorLogger("ERROR: %v", err)
 		return 0, err
 	}
 
@@ -492,7 +492,7 @@ func getTotalCpuUsageByPid(pid int32) (float64, error) {
 	for _, child := range children {
 		cpuUsage, err := child.CPUPercent()
 		if err != nil {
-			logger.ErrorLogger().Printf("ERROR: %v", err)
+			logger.ErrorLogger("ERROR: %v", err)
 			return 0, err
 		}
 		totCpu += cpuUsage
@@ -511,7 +511,7 @@ func (r *ContainerRuntime) ResourceMonitoring(every time.Duration, notifyHandler
 	for range ticker.C {
 		deployedContainers, err := r.containerClient.Containers(r.ctx)
 		if err != nil {
-			logger.ErrorLogger().Printf("Unable to fetch running containers: %v", err)
+			logger.ErrorLogger("Unable to fetch running containers: %v", err)
 		}
 
 		resourceList := make([]model.Resources, 0)
@@ -519,17 +519,17 @@ func (r *ContainerRuntime) ResourceMonitoring(every time.Duration, notifyHandler
 		for _, container := range deployedContainers {
 			task, err := container.Task(r.ctx, nil)
 			if err != nil {
-				logger.ErrorLogger().Printf("Unable to fetch container task: %v", err)
+				logger.ErrorLogger("Unable to fetch container task: %v", err)
 
 				info, err := container.Info(r.ctx)
 				if err != nil {
-					logger.ErrorLogger().Printf("Unable to fetch container info: %v", err)
+					logger.ErrorLogger("Unable to fetch container info: %v", err)
 					continue
 				}
 
 				// if container created less than 10 seconds ago, then skip removal
 				if time.Since(info.CreatedAt) < 10*time.Second {
-					logger.InfoLogger().Printf("Skipping container %s, it is still starting up", container.ID())
+					logger.InfoLogger("Skipping container %s, it is still starting up", container.ID())
 					continue
 				}
 
@@ -541,7 +541,7 @@ func (r *ContainerRuntime) ResourceMonitoring(every time.Duration, notifyHandler
 			if err != nil {
 				sysInfo, err := pidusage.GetStat(int(task.Pid()))
 				if err != nil {
-					logger.ErrorLogger().Printf("Unable to fetch task info: %v", err)
+					logger.ErrorLogger("Unable to fetch task info: %v", err)
 					continue
 				}
 				cpuUsage = sysInfo.CPU / float64(model.GetNodeInfo().CpuCores)
@@ -549,20 +549,20 @@ func (r *ContainerRuntime) ResourceMonitoring(every time.Duration, notifyHandler
 
 			memUsage, err := r.getContainerMemoryUsage(container.ID(), int(task.Pid()))
 			if err != nil {
-				logger.ErrorLogger().Printf("Unable to fetch container Memory: %v", err)
+				logger.ErrorLogger("Unable to fetch container Memory: %v", err)
 				memUsage = 0
 			}
 
 			containerMetadata, err := container.Info(r.ctx)
 			if err != nil {
-				logger.ErrorLogger().Printf("Unable to fetch container metadata: %v", err)
+				logger.ErrorLogger("Unable to fetch container metadata: %v", err)
 				continue
 			}
 
 			currentsnapshotter := r.containerClient.SnapshotService(containerMetadata.Snapshotter)
 			usage, err := currentsnapshotter.Usage(r.ctx, containerMetadata.SnapshotKey)
 			if err != nil {
-				logger.ErrorLogger().Printf("Unable to fetch task disk usage: %v", err)
+				logger.ErrorLogger("Unable to fetch task disk usage: %v", err)
 			}
 
 			resourceList = append(resourceList, model.Resources{
@@ -583,7 +583,7 @@ func (r *ContainerRuntime) ResourceMonitoring(every time.Duration, notifyHandler
 func (r *ContainerRuntime) forceContainerCleanup() {
 	deployedContainers, err := r.containerClient.Containers(r.ctx)
 	if err != nil {
-		logger.ErrorLogger().Printf("Unable to fetch running containers: %v", err)
+		logger.ErrorLogger("Unable to fetch running containers: %v", err)
 	}
 	for _, container := range deployedContainers {
 		_ = r.removeContainer(container)
@@ -592,14 +592,14 @@ func (r *ContainerRuntime) forceContainerCleanup() {
 
 func (r *ContainerRuntime) removeContainer(container ctd.Container) error {
 	if container == nil {
-		logger.WarnLogger().Printf("Container is nil, nothing to remove")
+		logger.WarnLogger("Container is nil, nothing to remove")
 		return nil
 	}
 
-	logger.InfoLogger().Printf("Cleaning up container: %s", container.ID())
+	logger.InfoLogger("Cleaning up container: %s", container.ID())
 	containerMetadata, err := container.Info(r.ctx)
 	if err != nil {
-		logger.ErrorLogger().Printf("Unable to fetch container metadata: %v", err)
+		logger.ErrorLogger("Unable to fetch container metadata: %v", err)
 	}
 
 	//kill task
@@ -607,7 +607,7 @@ func (r *ContainerRuntime) removeContainer(container ctd.Container) error {
 	if err == nil {
 		err := killTask(r.ctx, task, container)
 		if err != nil {
-			logger.ErrorLogger().Printf("Unable to kill task: %v", err)
+			logger.ErrorLogger("Unable to kill task: %v", err)
 		}
 	}
 
@@ -617,11 +617,11 @@ func (r *ContainerRuntime) removeContainer(container ctd.Container) error {
 		if currentsnapshotter != nil {
 			err = currentsnapshotter.Remove(r.ctx, containerMetadata.SnapshotKey)
 			if err != nil {
-				logger.WarnLogger().Printf("Unable to remove snapshotter %s: %v", containerMetadata.Snapshotter, err)
+				logger.WarnLogger("Unable to remove snapshotter %s: %v", containerMetadata.Snapshotter, err)
 			}
 			err = currentsnapshotter.Close()
 			if err != nil {
-				logger.WarnLogger().Printf("Unable to close snapshotter %s: %v", containerMetadata.Snapshotter, err)
+				logger.WarnLogger("Unable to close snapshotter %s: %v", containerMetadata.Snapshotter, err)
 			}
 		}
 	}
@@ -629,7 +629,7 @@ func (r *ContainerRuntime) removeContainer(container ctd.Container) error {
 	// remove container
 	err = container.Delete(r.ctx)
 	if err != nil {
-		logger.ErrorLogger().Printf("Unable to delete container: %v", err)
+		logger.ErrorLogger("Unable to delete container: %v", err)
 		return err
 	}
 
@@ -685,7 +685,7 @@ func withCSIVolumeMounts(mounts []csi.MountedVolume) func(context.Context, oci.C
 				Source:      mv.TargetPath,
 				Options:     []string{"rbind", "rw"},
 			})
-			logger.InfoLogger().Printf("CSI volume %s bind-mounted %s -> %s", mv.VolumeID, mv.TargetPath, dest)
+			logger.InfoLogger("CSI volume %s bind-mounted %s -> %s", mv.VolumeID, mv.TargetPath, dest)
 		}
 		return nil
 	}
@@ -694,23 +694,23 @@ func withCSIVolumeMounts(mounts []csi.MountedVolume) func(context.Context, oci.C
 func getResolveConfFile() (string, error) {
 	//check if /run/systemd/resolve/resolv.conf exists and use that
 	if _, err := os.Stat("/run/systemd/resolve/resolv.conf"); err == nil {
-		logger.InfoLogger().Printf("Using systemd-resolved resolv.conf")
+		logger.InfoLogger("Using systemd-resolved resolv.conf")
 		return "/run/systemd/resolve/resolv.conf", nil
 	}
 
 	file, err := os.CreateTemp("/tmp", "oakestra-resolv-conf")
 	if err != nil {
-		logger.ErrorLogger().Printf("Unable to create temp resolv file: %v", err)
+		logger.ErrorLogger("Unable to create temp resolv file: %v", err)
 		return "", err
 	}
 	defer func() {
 		if err := file.Close(); err != nil {
-			logger.ErrorLogger().Printf("Unable to close temp resolv file: %v", err)
+			logger.ErrorLogger("Unable to close temp resolv file: %v", err)
 		}
 	}()
 	_, err = file.WriteString("nameserver 8.8.8.8\n")
 	if err != nil {
-		logger.ErrorLogger().Printf("Unable to write temp resolv file: %v", err)
+		logger.ErrorLogger("Unable to write temp resolv file: %v", err)
 		return "", err
 	}
 	_ = file.Chmod(0444)
@@ -721,18 +721,18 @@ func killTask(ctx context.Context, task ctd.Task, container ctd.Container) error
 	//removing the task
 	p, err := task.LoadProcess(ctx, task.ID(), nil)
 	if err != nil {
-		logger.ErrorLogger().Printf("ERROR deleting the task, LoadProcess: %v", err)
+		logger.ErrorLogger("ERROR deleting the task, LoadProcess: %v", err)
 		return err
 	}
 	_, err = p.Delete(ctx, ctd.WithProcessKill)
 	if err != nil {
-		logger.ErrorLogger().Printf("ERROR deleting the task, Delete: %v", err)
+		logger.ErrorLogger("ERROR deleting the task, Delete: %v", err)
 		return err
 	}
 	_, _ = task.Delete(ctx)
 	_ = container.Delete(ctx)
 
-	logger.ErrorLogger().Printf("Task %s terminated", task.ID())
+	logger.ErrorLogger("Task %s terminated", task.ID())
 	return nil
 }
 
@@ -759,7 +759,7 @@ func selectBestGPUs(requested int) ([]int, error) {
 	// Cap requested GPUs to available GPUs
 	numGPUs := requested
 	if numGPUs > totalGPUs {
-		logger.WarnLogger().Printf("Requested %d GPUs but only %d available, using %d", requested, totalGPUs, totalGPUs)
+		logger.WarnLogger("Requested %d GPUs but only %d available, using %d", requested, totalGPUs, totalGPUs)
 		numGPUs = totalGPUs
 	}
 
@@ -769,25 +769,25 @@ func selectBestGPUs(requested int) ([]int, error) {
 		// Query free memory (memory.free) and total memory (memory.total)
 		freeMemStr, err := gpu.NvsmiQuery(fmt.Sprintf("%d", i), "memory.free")
 		if err != nil {
-			logger.WarnLogger().Printf("Failed to query free memory for GPU %d: %v", i, err)
+			logger.WarnLogger("Failed to query free memory for GPU %d: %v", i, err)
 			continue
 		}
 
 		totalMemStr, err := gpu.NvsmiQuery(fmt.Sprintf("%d", i), "memory.total")
 		if err != nil {
-			logger.WarnLogger().Printf("Failed to query total memory for GPU %d: %v", i, err)
+			logger.WarnLogger("Failed to query total memory for GPU %d: %v", i, err)
 			continue
 		}
 
 		freeMem, err := strconv.ParseInt(freeMemStr, 10, 64)
 		if err != nil {
-			logger.WarnLogger().Printf("Failed to parse free memory for GPU %d: %v", i, err)
+			logger.WarnLogger("Failed to parse free memory for GPU %d: %v", i, err)
 			continue
 		}
 
 		totalMem, err := strconv.ParseInt(totalMemStr, 10, 64)
 		if err != nil {
-			logger.WarnLogger().Printf("Failed to parse total memory for GPU %d: %v", i, err)
+			logger.WarnLogger("Failed to parse total memory for GPU %d: %v", i, err)
 			continue
 		}
 
@@ -797,7 +797,7 @@ func selectBestGPUs(requested int) ([]int, error) {
 			totalMemory: totalMem,
 		})
 
-		logger.InfoLogger().Printf("GPU %d: %d MiB free / %d MiB total", i, freeMem, totalMem)
+		logger.InfoLogger("GPU %d: %d MiB free / %d MiB total", i, freeMem, totalMem)
 	}
 
 	if len(gpuList) == 0 {

--- a/go_node_engine/virtualization/internal/crosvm/internal/fsimg/copy.go
+++ b/go_node_engine/virtualization/internal/crosvm/internal/fsimg/copy.go
@@ -48,32 +48,32 @@ func CopySquashFsIntoExt4Img(squashfsPath string, ext4Path string, mountDirPath 
 	}
 	defer iotools.RemoveOrWarn(mountDirPath)
 
-	logger.InfoLogger().Printf("mounting ext4 image at %q to %q", ext4Path, mountDirPath)
+	logger.InfoLogger("mounting ext4 image at %q to %q", ext4Path, mountDirPath)
 
 	mountCmd := exec.Command(mountExecPath, "-t", "ext4", "-o", "loop", ext4Path, mountDirPath)
 	if err := mountCmd.Run(); err != nil {
-		logger.ErrorLogger().Printf("failed to run mount command: %v", err)
+		logger.ErrorLogger("failed to run mount command: %v", err)
 		return fmt.Errorf("failed to run mount command: %w", err)
 	}
 	defer func() {
 		umountCmd := exec.Command(umountExecPath, "-d", mountDirPath)
 		if err := umountCmd.Run(); err != nil {
-			logger.WarnLogger().Printf("failed to run umount command: %v", err)
+			logger.WarnLogger("failed to run umount command: %v", err)
 		}
 	}()
 
-	logger.InfoLogger().Printf("copying squashfs contents of %q to ext4 mount at %q", squashfsPath, mountDirPath)
+	logger.InfoLogger("copying squashfs contents of %q to ext4 mount at %q", squashfsPath, mountDirPath)
 
 	if err := UnpackFromSquashFsImg(squashfsPath, mountDirPath); err != nil {
-		logger.ErrorLogger().Printf("failed to unpack squashfs image: %v", err)
+		logger.ErrorLogger("failed to unpack squashfs image: %v", err)
 		return fmt.Errorf("failed to unpack squashfs image: %w", err)
 	}
 
 	if err := os.Chmod(mountDirPath, 0o755); err != nil {
-		logger.ErrorLogger().Printf("failed to set root directory permissions in image: %v", err)
+		logger.ErrorLogger("failed to set root directory permissions in image: %v", err)
 		return fmt.Errorf("failed to set root directory permissions in image: %w", err)
 	}
 
-	logger.InfoLogger().Printf("successfully copied squashfs contents of %q into ext4 image at %q", squashfsPath, ext4Path)
+	logger.InfoLogger("successfully copied squashfs contents of %q into ext4 image at %q", squashfsPath, ext4Path)
 	return nil
 }

--- a/go_node_engine/virtualization/internal/crosvm/internal/image/containers.go
+++ b/go_node_engine/virtualization/internal/crosvm/internal/image/containers.go
@@ -76,7 +76,7 @@ func (s *ContainersSource) Retrieve(id string, dstDirPath string) error {
 	layersDirRemoved := false // allow removing the layers directory early
 	layersDirPath, err := iotools.CreateSubDir(dstDirPath, "layers", 0o700)
 	if err != nil {
-		logger.ErrorLogger().Printf("failed to create layers directory for %q: %v", id, err)
+		logger.ErrorLogger("failed to create layers directory for %q: %v", id, err)
 		return err
 	}
 	defer func() {
@@ -87,7 +87,7 @@ func (s *ContainersSource) Retrieve(id string, dstDirPath string) error {
 
 	rootfsDirPath, err := iotools.CreateSubDir(dstDirPath, "rootfs", 0o700)
 	if err != nil {
-		logger.ErrorLogger().Printf("failed to create rootfs directory for %q: %v", id, err)
+		logger.ErrorLogger("failed to create rootfs directory for %q: %v", id, err)
 		return err
 	}
 	defer iotools.RemoveAllOrWarn(rootfsDirPath)
@@ -156,7 +156,7 @@ func (s *ContainersSource) Retrieve(id string, dstDirPath string) error {
 
 	// remove layers directory early to save disk space
 	if err := os.RemoveAll(layersDirPath); err != nil {
-		logger.WarnLogger().Printf("failed to remove directory %q", layersDirPath)
+		logger.WarnLogger("failed to remove directory %q", layersDirPath)
 	}
 	layersDirRemoved = true
 

--- a/go_node_engine/virtualization/internal/crosvm/internal/image/store.go
+++ b/go_node_engine/virtualization/internal/crosvm/internal/image/store.go
@@ -59,14 +59,14 @@ func NewStore(dirPath string, sources ...Source) (*Store, error) {
 	defaultSource := sources[0]
 
 	if err := os.Mkdir(dirPath, 0o700); err != nil && !os.IsExist(err) {
-		logger.ErrorLogger().Printf("failed to create store directory %q: %v", dirPath, err)
+		logger.ErrorLogger("failed to create store directory %q: %v", dirPath, err)
 		return nil, err
 	}
 
-	logger.InfoLogger().Printf("initializing store at %q", dirPath)
+	logger.InfoLogger("initializing store at %q", dirPath)
 	images, err := restoreImages(dirPath)
 	if err != nil {
-		logger.ErrorLogger().Printf("failed to restore images: %v", err)
+		logger.ErrorLogger("failed to restore images: %v", err)
 		return nil, err
 	}
 
@@ -77,7 +77,7 @@ func NewStore(dirPath string, sources ...Source) (*Store, error) {
 		totalSize += img.Size
 	}
 
-	logger.InfoLogger().Printf("restored %d images, total %d bytes", len(images), totalSize)
+	logger.InfoLogger("restored %d images, total %d bytes", len(images), totalSize)
 
 	p := &Store{
 		dirPath:       dirPath,
@@ -111,16 +111,16 @@ func (s *Store) Retrieve(ref string, dstDirPath string, rootfsSize int64) (*Imag
 
 	tmpDirPath, err := iotools.CreateLargeTempDir("image")
 	if err != nil {
-		logger.ErrorLogger().Printf("failed to create temporary directory for %q: %v", ref, err)
+		logger.ErrorLogger("failed to create temporary directory for %q: %v", ref, err)
 		return nil, err
 	}
 
-	logger.InfoLogger().Printf("retrieving image %q to %q...", id, tmpDirPath)
+	logger.InfoLogger("retrieving image %q to %q...", id, tmpDirPath)
 	if err = source.Retrieve(id, tmpDirPath); err != nil {
 		iotools.RemoveAllOrWarn(tmpDirPath)
 		return nil, err
 	}
-	logger.InfoLogger().Printf("retrieved image %q to %q", id, tmpDirPath)
+	logger.InfoLogger("retrieved image %q to %q", id, tmpDirPath)
 
 	img, err = CreateImageFromDir(tmpDirPath)
 	if err != nil {
@@ -128,12 +128,12 @@ func (s *Store) Retrieve(ref string, dstDirPath string, rootfsSize int64) (*Imag
 		return nil, err
 	}
 
-	logger.InfoLogger().Printf("copying image %q to destination %q...", id, dstDirPath)
+	logger.InfoLogger("copying image %q to destination %q...", id, dstDirPath)
 	if err := copyImageFilesToDst(tmpDirPath, dstDirPath, rootfsSize, img.HasInitrd); err != nil {
 		iotools.RemoveAllOrWarn(tmpDirPath)
 		return nil, err
 	}
-	logger.InfoLogger().Printf("copied image %q to destination %q", id, dstDirPath)
+	logger.InfoLogger("copied image %q to destination %q", id, dstDirPath)
 
 	go s.moveIntoCache(ref, img, tmpDirPath, imageDirPath)
 
@@ -143,11 +143,11 @@ func (s *Store) Retrieve(ref string, dstDirPath string, rootfsSize int64) (*Imag
 // Remove deletes every file of the cache and the cache directory itself.
 // After Remove returns, the Store cannot not be used anymore and calls on it will result in undefined behavior.
 func (s *Store) Remove() error {
-	logger.InfoLogger().Printf("removing cache at %q", s.dirPath)
+	logger.InfoLogger("removing cache at %q", s.dirPath)
 
 	imageEntries, err := os.ReadDir(s.dirPath)
 	if err != nil {
-		logger.ErrorLogger().Printf("failed to read directory %q: %v", s.dirPath, err)
+		logger.ErrorLogger("failed to read directory %q: %v", s.dirPath, err)
 		return err
 	}
 
@@ -157,13 +157,13 @@ func (s *Store) Remove() error {
 		imageDirPath := filepath.Join(s.dirPath, imageDirName)
 
 		if !isImageDir(imageDirPath) {
-			logger.WarnLogger().Printf("while removing store, found non-image directory %q, ignoring", imageDirPath)
+			logger.WarnLogger("while removing store, found non-image directory %q, ignoring", imageDirPath)
 			skippedEntry = true
 			continue
 		}
 
 		if err := os.RemoveAll(imageDirPath); err != nil {
-			logger.WarnLogger().Printf("while removing store, failed to remove image directory %q: %v", imageDirPath, err)
+			logger.WarnLogger("while removing store, failed to remove image directory %q: %v", imageDirPath, err)
 			skippedEntry = true
 			continue
 		}
@@ -171,7 +171,7 @@ func (s *Store) Remove() error {
 
 	if !skippedEntry {
 		if err := os.Remove(s.dirPath); err != nil {
-			logger.ErrorLogger().Printf("failed to remove store directory %q: %v", s.dirPath, err)
+			logger.ErrorLogger("failed to remove store directory %q: %v", s.dirPath, err)
 			return err
 		}
 	}
@@ -198,13 +198,13 @@ func (s *Store) retrieveFromCache(
 	if err := copyImageFilesToDst(imageDirPath, dstDirPath, rootfsSize, img.HasInitrd); err != nil {
 		// allow the cache to recover if a file of an entry was deleted, by pretending it wasn't cached
 		if os.IsNotExist(err) {
-			logger.WarnLogger().Printf("missing file for cached entry %q, restoring: %v", ref, err)
+			logger.WarnLogger("missing file for cached entry %q, restoring: %v", ref, err)
 			return false, nil, nil
 		}
 		return true, nil, err
 	}
 
-	logger.InfoLogger().Printf("cache hit for %q -> %q", ref, imageDirPath)
+	logger.InfoLogger("cache hit for %q -> %q", ref, imageDirPath)
 
 	return true, img, nil
 }
@@ -232,11 +232,11 @@ func (s *Store) moveIntoCache(ref string, img *Image, tmpDirPath string, imageDi
 		var errnoErr syscall.Errno
 		if ok := errors.As(err, &errnoErr); ok && errnoErr == 18 {
 			if err := iotools.CopyDir(tmpDirPath, imageDirPath); err != nil {
-				logger.ErrorLogger().Printf("failed to copy image %q into cache directory %q, it will be re-fetched the next time it is used: %v", imageDirPath, ref, err)
+				logger.ErrorLogger("failed to copy image %q into cache directory %q, it will be re-fetched the next time it is used: %v", imageDirPath, ref, err)
 				return
 			}
 		} else {
-			logger.ErrorLogger().Printf("failed to move image %q into cache directory %q, it will be re-fetched the next time it is used: %v", imageDirPath, ref, err)
+			logger.ErrorLogger("failed to move image %q into cache directory %q, it will be re-fetched the next time it is used: %v", imageDirPath, ref, err)
 			return
 		}
 	}
@@ -248,7 +248,7 @@ func (s *Store) moveIntoCache(ref string, img *Image, tmpDirPath string, imageDi
 	s.images[img.Key] = img
 	s.totalSize += img.Size
 
-	logger.InfoLogger().Printf("moved image %q into cache at %q, total size is now %d bytes", ref, imageDirPath, s.totalSize)
+	logger.InfoLogger("moved image %q into cache at %q, total size is now %d bytes", ref, imageDirPath, s.totalSize)
 }
 
 // parseRef takes an image reference and splits it into its source and id parts
@@ -314,7 +314,7 @@ func convertIdToKey(source Source, id string) string {
 func restoreImages(dirPath string) ([]Image, error) {
 	imageEntries, err := os.ReadDir(dirPath)
 	if err != nil {
-		logger.ErrorLogger().Printf("failed to read store directory %q: %v", dirPath, err)
+		logger.ErrorLogger("failed to read store directory %q: %v", dirPath, err)
 		return nil, err
 	}
 
@@ -324,7 +324,7 @@ func restoreImages(dirPath string) ([]Image, error) {
 		imageDirPath := filepath.Join(dirPath, imageDirName)
 
 		if !isImageDir(imageDirPath) {
-			logger.WarnLogger().Printf("while initializing store, found non-image directory %q, ignoring", imageDirPath)
+			logger.WarnLogger("while initializing store, found non-image directory %q, ignoring", imageDirPath)
 			continue
 		}
 

--- a/go_node_engine/virtualization/internal/crosvm/internal/instance/instance.go
+++ b/go_node_engine/virtualization/internal/crosvm/internal/instance/instance.go
@@ -122,12 +122,12 @@ func NewInstance(
 		return nil, err
 	}
 
-	logger.InfoLogger().Printf("setting up network for instance %q...", id)
+	logger.InfoLogger("setting up network for instance %q...", id)
 	netConf, err := setupNetwork(service)
 	if err != nil {
 		return nil, err
 	}
-	logger.InfoLogger().Printf("set up network for instance %q", id)
+	logger.InfoLogger("set up network for instance %q", id)
 
 	socketPath := path.Join(baseRuntimeDirPath, uuid.New().String()+".sock")
 
@@ -177,7 +177,7 @@ func NewInstance(
 	_, _ = inst.outputBuffer.Write([]byte{'\n'})
 
 	if err := inst.createConfigFile(); err != nil {
-		logger.ErrorLogger().Printf("could not create config file for instance %q: %v", inst.id, err)
+		logger.ErrorLogger("could not create config file for instance %q: %v", inst.id, err)
 		_ = inst.Close()
 		return nil, err
 	}
@@ -234,7 +234,7 @@ func NewInstance(
 		path.Join(inst.stateDirPath, cloudInitFileName),
 	)
 	if err != nil {
-		logger.ErrorLogger().Printf("could not create cloud-init drive for instance %q: %v", inst.id, err)
+		logger.ErrorLogger("could not create cloud-init drive for instance %q: %v", inst.id, err)
 		_ = inst.Close()
 		return nil, err
 	}
@@ -247,12 +247,12 @@ func (i *Instance) Start() error {
 	defer i.lock.Unlock()
 
 	if i.status == instanceStatusRunning {
-		logger.WarnLogger().Printf("ignoring instance start for %q, because it is already running", i.id)
+		logger.WarnLogger("ignoring instance start for %q, because it is already running", i.id)
 		return nil
 	}
 
 	if i.status == instanceStatusClosed {
-		logger.ErrorLogger().Printf("ignoring instance start for %q, because it is already closed", i.id)
+		logger.ErrorLogger("ignoring instance start for %q, because it is already closed", i.id)
 		return errAlreadyClosed
 	}
 
@@ -273,12 +273,12 @@ func (i *Instance) Start() error {
 	runCmd.Stdout = outputWriter
 	runCmd.Stderr = outputWriter
 
-	logger.InfoLogger().Printf("starting instance %q with args %q", i.id, runArgs)
+	logger.InfoLogger("starting instance %q with args %q", i.id, runArgs)
 	if err := runCmd.Start(); err != nil {
-		logger.ErrorLogger().Printf("failed to start instance %q: %v", i.id, err)
+		logger.ErrorLogger("failed to start instance %q: %v", i.id, err)
 		return err
 	}
-	logger.InfoLogger().Printf("started instance %q", i.id)
+	logger.InfoLogger("started instance %q", i.id)
 
 	i.startCount++
 	i.status = instanceStatusRunning
@@ -298,7 +298,7 @@ func (i *Instance) Stop() error {
 	}
 
 	if err := i.stopInternal(); err != nil {
-		logger.WarnLogger().Printf("Stopping crosvm instance %q via command failed: %v", i.id, err)
+		logger.WarnLogger("Stopping crosvm instance %q via command failed: %v", i.id, err)
 	}
 
 	select {
@@ -323,7 +323,7 @@ func (i *Instance) Close() error {
 
 	if i.status == instanceStatusRunning {
 		if err := i.stopInternal(); err != nil {
-			logger.WarnLogger().Printf("Stopping crosvm instance %q via command failed: %v", i.id, err)
+			logger.WarnLogger("Stopping crosvm instance %q via command failed: %v", i.id, err)
 		}
 		select {
 		case exit := <-i.exitChan:
@@ -388,7 +388,7 @@ func (i *Instance) waitForExit(cmd *exec.Cmd, startNum uint32) {
 
 	var exit instanceExitType
 	if runErr == nil {
-		logger.InfoLogger().Printf("instance %q exited successfully", i.id)
+		logger.InfoLogger("instance %q exited successfully", i.id)
 		exit = instanceExitTypeSuccess
 	} else {
 		var err *exec.ExitError
@@ -406,9 +406,9 @@ func (i *Instance) waitForExit(cmd *exec.Cmd, startNum uint32) {
 				}
 			}
 
-			logger.ErrorLogger().Print(msgBuilder.String())
+			logger.ErrorLogger(msgBuilder.String())
 		} else {
-			logger.ErrorLogger().Printf("unexpected error when trying to run instance %q: %v", i.id, runErr)
+			logger.ErrorLogger("unexpected error when trying to run instance %q: %v", i.id, runErr)
 		}
 		exit = instanceExitTypeError
 	}
@@ -421,7 +421,7 @@ func (i *Instance) waitForExit(cmd *exec.Cmd, startNum uint32) {
 	case i.exitChan <- exit:
 		break
 	default:
-		logger.ErrorLogger().Printf(
+		logger.ErrorLogger(
 			"instance %q exit could not be emitted into channel, this should never happen", i.id,
 		)
 		return
@@ -474,7 +474,7 @@ func (i *Instance) restart() {
 	go func() {
 		err := i.Start()
 		if err != nil {
-			logger.ErrorLogger().Printf("failed to restart instance %q: %v", i.id, err)
+			logger.ErrorLogger("failed to restart instance %q: %v", i.id, err)
 		}
 	}()
 }

--- a/go_node_engine/virtualization/internal/crosvm/internal/instance/network.go
+++ b/go_node_engine/virtualization/internal/crosvm/internal/instance/network.go
@@ -21,7 +21,7 @@ func setupNetwork(service model.Service) (*networkConfig, error) {
 	}
 
 	if err := requests.CreateNetworkNamespaceForUnikernel(service.Sname, service.Instance, service.Ports); err != nil {
-		logger.ErrorLogger().Printf("network creation failed: %v", err)
+		logger.ErrorLogger("network creation failed: %v", err)
 		return nil, err
 	}
 
@@ -43,7 +43,7 @@ func teardownNetwork(service model.Service) error {
 	}
 
 	if err := requests.DeleteNamespaceForUnikernel(service.Sname, service.Instance); err != nil {
-		logger.ErrorLogger().Printf("network deletion failed: %v", err)
+		logger.ErrorLogger("network deletion failed: %v", err)
 		return err
 	}
 

--- a/go_node_engine/virtualization/internal/crosvm/runtime.go
+++ b/go_node_engine/virtualization/internal/crosvm/runtime.go
@@ -48,7 +48,7 @@ type Runtime struct {
 func newRuntime(info virtrt.RuntimeInfo) virtrt.Runtime {
 	systemMetricsTracker, err := stats.NewSystemMetricsTracker()
 	if err != nil {
-		logger.ErrorLogger().Printf("failed to create SystemMetricsTracker: %v", err)
+		logger.ErrorLogger("failed to create SystemMetricsTracker: %v", err)
 		return &Runtime{
 			error: err,
 		}
@@ -56,7 +56,7 @@ func newRuntime(info virtrt.RuntimeInfo) virtrt.Runtime {
 
 	// this is a workaround for a known issue in crosvm, which causes it to fail when /var/empty does not exist
 	if err := os.MkdirAll("/var/empty", 0o755); err != nil {
-		logger.ErrorLogger().Printf("failed to create /var/empty directory: %v", err)
+		logger.ErrorLogger("failed to create /var/empty directory: %v", err)
 		return &Runtime{
 			error: err,
 		}
@@ -64,7 +64,7 @@ func newRuntime(info virtrt.RuntimeInfo) virtrt.Runtime {
 
 	executablePath, err := exec.LookPath(executableName)
 	if err != nil {
-		logger.ErrorLogger().Printf("unable to find crosvm executable (%s): %v\n", executableName, err)
+		logger.ErrorLogger("unable to find crosvm executable (%s): %v\n", executableName, err)
 		return &Runtime{
 			error: err,
 		}
@@ -72,7 +72,7 @@ func newRuntime(info virtrt.RuntimeInfo) virtrt.Runtime {
 
 	runtimeDirPath, err := iotools.CreateSubDir(info.RuntimeDirPath, "crosvm", 0o700)
 	if err != nil {
-		logger.ErrorLogger().Printf("failed to setup runtime directory for crosvm runtime: %v", err)
+		logger.ErrorLogger("failed to setup runtime directory for crosvm runtime: %v", err)
 		return &Runtime{
 			error: err,
 		}
@@ -80,7 +80,7 @@ func newRuntime(info virtrt.RuntimeInfo) virtrt.Runtime {
 
 	stateDirPath, err := iotools.CreateSubDir(info.StateDirPath, "crosvm", 0o700)
 	if err != nil {
-		logger.ErrorLogger().Printf("failed to setup state directory for crosvm runtime: %v", err)
+		logger.ErrorLogger("failed to setup state directory for crosvm runtime: %v", err)
 		return &Runtime{
 			error: err,
 		}
@@ -88,7 +88,7 @@ func newRuntime(info virtrt.RuntimeInfo) virtrt.Runtime {
 
 	cacheDirPath, err := iotools.CreateSubDir(info.CacheDirPath, "crosvm", 0o700)
 	if err != nil {
-		logger.ErrorLogger().Printf("failed to setup cache directory for crosvm runtime: %v", err)
+		logger.ErrorLogger("failed to setup cache directory for crosvm runtime: %v", err)
 		return &Runtime{
 			error: err,
 		}
@@ -96,7 +96,7 @@ func newRuntime(info virtrt.RuntimeInfo) virtrt.Runtime {
 
 	imageDirPath, err := iotools.CreateSubDir(cacheDirPath, "images", 0o700)
 	if err != nil {
-		logger.ErrorLogger().Printf("failed to setup directory for crosvm images: %v", err)
+		logger.ErrorLogger("failed to setup directory for crosvm images: %v", err)
 		return &Runtime{
 			error: err,
 		}
@@ -104,7 +104,7 @@ func newRuntime(info virtrt.RuntimeInfo) virtrt.Runtime {
 
 	imageStore, err := image.NewStore(imageDirPath, image.NewContainersSource(docker.Transport))
 	if err != nil {
-		logger.ErrorLogger().Printf("failed to create crosvm image store: %v", err)
+		logger.ErrorLogger("failed to create crosvm image store: %v", err)
 		return &Runtime{
 			error: err,
 		}
@@ -116,7 +116,7 @@ func newRuntime(info virtrt.RuntimeInfo) virtrt.Runtime {
 	_, _ = fmt.Fprintf(&infoMsg, "  > runtime directory: %s\n", runtimeDirPath)
 	_, _ = fmt.Fprintf(&infoMsg, "  > state directory: %s\n", stateDirPath)
 	_, _ = fmt.Fprintf(&infoMsg, "  > cache directory: %s\n", cacheDirPath)
-	logger.InfoLogger().Print(infoMsg.String())
+	logger.InfoLogger(infoMsg.String())
 
 	return &Runtime{
 		error: nil,
@@ -201,7 +201,7 @@ func (r *Runtime) Stop() {
 		go func(id string, inst *instance.Instance) {
 			defer wg.Done()
 			if err := inst.Close(); err != nil {
-				logger.ErrorLogger().Printf("unable to stop and close instance %q: %v", id, err)
+				logger.ErrorLogger("unable to stop and close instance %q: %v", id, err)
 				// TODO(axiphi): What do we do in case of an error here? It might be problematic to just keep the VM running.
 			}
 		}(id, inst)
@@ -228,7 +228,7 @@ func (r *Runtime) reportResources(notifyHandler func(res []model.Resources)) {
 
 	systemMetrics, err := r.systemMetricsTracker.GatherMetrics()
 	if err != nil {
-		logger.WarnLogger().Printf("failed to gather system metrics: %v", err)
+		logger.WarnLogger("failed to gather system metrics: %v", err)
 		return
 	}
 

--- a/go_node_engine/virtualization/internal/logutils/logutils.go
+++ b/go_node_engine/virtualization/internal/logutils/logutils.go
@@ -14,20 +14,20 @@ func GetLogs(serviceID string) string {
 
 	file, err := os.Open(fmt.Sprintf("%s/%s", model.GetNodeInfo().LogDirectory, serviceID))
 	if err != nil {
-		logger.ErrorLogger().Printf("%v", err)
+		logger.ErrorLogger("%v", err)
 		return ""
 	}
 	//defer file.Close()
 	defer func() {
 		if err := file.Close(); err != nil {
-			logger.ErrorLogger().Printf("%v", err)
+			logger.ErrorLogger("%v", err)
 		}
 	}()
 
 	buf := make([]byte, LOG_SIZE)
 	stat, err := file.Stat()
 	if err != nil {
-		logger.ErrorLogger().Printf("%v", err)
+		logger.ErrorLogger("%v", err)
 		return ""
 	}
 

--- a/go_node_engine/virtualization/internal/unikernel/UnikernelManagement.go
+++ b/go_node_engine/virtualization/internal/unikernel/UnikernelManagement.go
@@ -64,21 +64,21 @@ func newUnikernelQemuRuntime(_ virtrt.RuntimeInfo) virtrt.Runtime {
 
 	path, err := exec.LookPath(command)
 	if err != nil {
-		logger.ErrorLogger().Printf("Unable to find qemu executable(%s): %v\n", command, err)
+		logger.ErrorLogger("Unable to find qemu executable(%s): %v\n", command, err)
 		ukruntime.qemuPath = ""
 	}
 	ukruntime.qemuPath = path
-	logger.InfoLogger().Printf("Using qemu at %s\n", path)
+	logger.InfoLogger("Using qemu at %s\n", path)
 	ukruntime.killQueue = make(map[string]*chan bool)
 	ukruntime.qemuDomains = make(map[string]*qemuDomain)
 	err = os.MkdirAll("/tmp/node_engine/kernel/tmp/", 0755)
 	if err != nil {
-		logger.ErrorLogger().Printf("Unable to create kernel directory: %v", err)
+		logger.ErrorLogger("Unable to create kernel directory: %v", err)
 	}
 
 	err = os.MkdirAll("/tmp/node_engine/inst/", 0755)
 	if err != nil {
-		logger.ErrorLogger().Printf("Unable to create instance directory: %v", err)
+		logger.ErrorLogger("Unable to create instance directory: %v", err)
 	}
 
 	return &ukruntime
@@ -92,14 +92,14 @@ func (r *UnikernelRuntime) Stop() {
 		if r.killQueue[id.String()] == nil {
 			continue
 		}
-		logger.InfoLogger().Printf("Stopping VM %s : %s %d\n", id.String(), taskid.ExtractServiceName(id.String()), taskid.ExtractInstanceNumber(id.String()))
+		logger.InfoLogger("Stopping VM %s : %s %d\n", id.String(), taskid.ExtractServiceName(id.String()), taskid.ExtractInstanceNumber(id.String()))
 		err := r.Undeploy(taskid.ExtractServiceName(id.String()), taskid.ExtractInstanceNumber(id.String()))
 		if err != nil {
-			logger.ErrorLogger().Printf("Unable to undeploy %s, error: %v", id.String(), err)
+			logger.ErrorLogger("Unable to undeploy %s, error: %v", id.String(), err)
 		}
 	}
 
-	logger.InfoLogger().Print("Stopped all Unikernel deployments\n")
+	logger.InfoLogger("Stopped all Unikernel deployments\n")
 }
 
 func (r *UnikernelRuntime) Deploy(service model.Service, statusChangeNotificationHandler func(service model.Service)) error {
@@ -118,7 +118,7 @@ func (r *UnikernelRuntime) Deploy(service model.Service, statusChangeNotificatio
 	} else {
 		return errors.New("service already deployed")
 	}
-	logger.InfoLogger().Println("Start Unikernel creation")
+	logger.InfoLogger("Start Unikernel creation")
 	go r.VirtualMachineCreationRoutine(service, &killChannel, startupChannel, errorChannel, statusChangeNotificationHandler)
 
 	if !<-startupChannel {
@@ -136,15 +136,15 @@ func (r *UnikernelRuntime) Undeploy(service string, instance int) error {
 	//r.qemuDomains = append(r.qemuDomains, hostname)
 	el, found := r.killQueue[hostname]
 	if found && el != nil {
-		logger.InfoLogger().Printf("Sending kill signal to VM with hostname: %s", hostname)
+		logger.InfoLogger("Sending kill signal to VM with hostname: %s", hostname)
 		*r.killQueue[hostname] <- true
 		select {
 		case res := <-*r.killQueue[hostname]:
 			if !res {
-				logger.ErrorLogger().Printf("Unable to stop VM %s", hostname)
+				logger.ErrorLogger("Unable to stop VM %s", hostname)
 			}
 		case <-time.After(5 * time.Second):
-			logger.ErrorLogger().Printf("Unable to stop service %s", hostname)
+			logger.ErrorLogger("Unable to stop service %s", hostname)
 		}
 
 		delete(r.killQueue, hostname)
@@ -185,56 +185,56 @@ func GetKernelImage(kernel string, name string, sname string) *string {
 		return nil
 	}
 	if err := os.Mkdir(instance_path, 0777); err != nil {
-		logger.InfoLogger().Printf("Unable to create instance directory: %v", err)
+		logger.InfoLogger("Unable to create instance directory: %v", err)
 	}
 
 	var kimage *os.File
 	_, err = os.Stat(kernel_tar)
 	if err != nil {
-		logger.InfoLogger().Printf("Kernel not found locally")
+		logger.InfoLogger("Kernel not found locally")
 		kimage, err = os.Create(kernel_tar)
 
 		if err != nil {
-			logger.InfoLogger().Printf("Unable to create Kernel: %v", err)
+			logger.InfoLogger("Unable to create Kernel: %v", err)
 			return nil
 		}
 
 		//defer kimage.Close()
 		defer func() {
 			if err := kimage.Close(); err != nil {
-				logger.InfoLogger().Printf("Unable to close kernel image: %v", err)
+				logger.InfoLogger("Unable to close kernel image: %v", err)
 			}
 		}()
 		d, err := http.Get(kernel)
 		if err != nil {
-			logger.InfoLogger().Printf("Unable to locate kernel image (%s): %v", kernel, err)
+			logger.InfoLogger("Unable to locate kernel image (%s): %v", kernel, err)
 			err := os.Remove(kernel_tar)
 			if err != nil {
-				logger.InfoLogger().Printf("Unable to remove kernel image: %v", err)
+				logger.InfoLogger("Unable to remove kernel image: %v", err)
 			}
 			return nil
 		}
 		size, err := io.Copy(kimage, d.Body)
 		if err != nil {
-			logger.InfoLogger().Printf("Kernel download failed: %v", err)
+			logger.InfoLogger("Kernel download failed: %v", err)
 			err := os.Remove(kernel_tar)
 			if err != nil {
-				logger.InfoLogger().Printf("Unable to remove kernel image: %v", err)
+				logger.InfoLogger("Unable to remove kernel image: %v", err)
 			}
 			return nil
 		}
 		if err := d.Body.Close(); err != nil {
-			logger.InfoLogger().Printf("Unable to close kernel image: %v", err)
+			logger.InfoLogger("Unable to close kernel image: %v", err)
 		}
 
-		logger.InfoLogger().Printf("Written %d B", size)
+		logger.InfoLogger("Written %d B", size)
 
 		if err := kimage.Close(); err != nil {
-			logger.InfoLogger().Printf("Unable to close kernel image: %v", err)
+			logger.InfoLogger("Unable to close kernel image: %v", err)
 		}
 
 		if err := os.Mkdir(kernel_location, 0777); err != nil {
-			logger.InfoLogger().Printf("Unable to create kernel directory: %v", err)
+			logger.InfoLogger("Unable to create kernel directory: %v", err)
 		}
 		/*unpack Kernel and additional data*/
 		kimage, _ = os.Open(kernel_tar)
@@ -242,13 +242,13 @@ func GetKernelImage(kernel string, name string, sname string) *string {
 
 		defer func() {
 			if err := kimage.Close(); err != nil {
-				logger.InfoLogger().Printf("Unable to close kernel image: %v", err)
+				logger.InfoLogger("Unable to close kernel image: %v", err)
 			}
 		}()
 
 		exdata, err := gzip.NewReader(kimage)
 		if err != nil {
-			logger.InfoLogger().Printf("Unable to open kernel archive: %v", err)
+			logger.InfoLogger("Unable to open kernel archive: %v", err)
 		}
 		tardata := tar.NewReader(exdata)
 
@@ -259,7 +259,7 @@ func GetKernelImage(kernel string, name string, sname string) *string {
 				if err == io.EOF {
 					break
 				}
-				logger.InfoLogger().Printf("Unable to read tar: %v", err)
+				logger.InfoLogger("Unable to read tar: %v", err)
 				return nil
 			}
 
@@ -267,69 +267,69 @@ func GetKernelImage(kernel string, name string, sname string) *string {
 			case tar.TypeDir:
 				err := os.Mkdir(kernel_location+header.Name, 0777)
 				if err != nil {
-					logger.InfoLogger().Printf("Unable to create dir: %v", err)
+					logger.InfoLogger("Unable to create dir: %v", err)
 				}
 			case tar.TypeReg:
 				file, err := os.Create(kernel_location + header.Name)
 				if err != nil {
-					logger.InfoLogger().Printf("Unable to create file: %v", err)
+					logger.InfoLogger("Unable to create file: %v", err)
 				}
 				err = file.Chmod(header.FileInfo().Mode())
 				if err != nil {
-					logger.InfoLogger().Printf("Unable to chmod file: %v", err)
+					logger.InfoLogger("Unable to chmod file: %v", err)
 				}
 				_, err = io.Copy(file, tardata)
 				if err != nil {
-					logger.InfoLogger().Printf("File copy failed: %v", err)
+					logger.InfoLogger("File copy failed: %v", err)
 				}
 			default:
-				logger.InfoLogger().Printf("ERROR: incorrect typeflag")
+				logger.InfoLogger("ERROR: incorrect typeflag")
 				return nil
 
 			}
 
 		}
 	} else {
-		logger.InfoLogger().Printf("Kernel found locally")
+		logger.InfoLogger("Kernel found locally")
 	}
 	if err != nil {
-		logger.InfoLogger().Printf("Unable to open kernel archive: %v", err)
+		logger.InfoLogger("Unable to open kernel archive: %v", err)
 		return nil
 	}
 
 	_, err = os.Stat(kernel_location + "files")
 	if !errors.Is(err, fs.ErrNotExist) {
-		logger.InfoLogger().Printf("Creating new instance envioument %s -> %s", kernel_location+"files", instance_path)
+		logger.InfoLogger("Creating new instance envioument %s -> %s", kernel_location+"files", instance_path)
 
 		err = exec.Command("cp", "-r", kernel_location+"files", instance_path).Run()
 		if err != nil {
-			logger.InfoLogger().Printf("Unable to set files: %v", err)
+			logger.InfoLogger("Unable to set files: %v", err)
 		}
 	}
 
 	_, err = os.Stat(kernel_location + "files1")
 	if !errors.Is(err, fs.ErrNotExist) {
-		logger.InfoLogger().Printf("Creating new instance environment %s -> %s", kernel_location+"files1", instance_path+"/files")
+		logger.InfoLogger("Creating new instance environment %s -> %s", kernel_location+"files1", instance_path+"/files")
 
 		err = exec.Command("cp", "-r", kernel_location+"files1", instance_path).Run()
 		if err != nil {
-			logger.InfoLogger().Printf("Unable to set files: %v", err)
+			logger.InfoLogger("Unable to set files: %v", err)
 		}
 
 		err = exec.Command("mv", instance_path+"/files1", instance_path+"/files").Run()
 		if err != nil {
-			logger.InfoLogger().Printf("Unable to set files: %v", err)
+			logger.InfoLogger("Unable to set files: %v", err)
 		}
 
 	}
 
 	_, err = os.Stat(kernel_location + "initramfs.cpio")
 	if !errors.Is(err, fs.ErrNotExist) {
-		logger.InfoLogger().Printf("Creating new ramdisk envioument %s -> %s", kernel_location+"initramfs.cpio", instance_path+"/initramfs.cpio")
+		logger.InfoLogger("Creating new ramdisk envioument %s -> %s", kernel_location+"initramfs.cpio", instance_path+"/initramfs.cpio")
 
 		err = exec.Command("cp", "-r", kernel_location+"initramfs.cpio", instance_path).Run()
 		if err != nil {
-			logger.InfoLogger().Printf("Unable to set files: %v", err)
+			logger.InfoLogger("Unable to set files: %v", err)
 		}
 
 	}
@@ -337,17 +337,17 @@ func GetKernelImage(kernel string, name string, sname string) *string {
 	//Kernel image is expected at a fixed location within the archive ./kernel
 	_, err = os.Stat(kernel_local)
 	if err != nil {
-		logger.InfoLogger().Printf("Archive does not seem to contain the kernel image: %v", err)
+		logger.InfoLogger("Archive does not seem to contain the kernel image: %v", err)
 		return nil
 	}
-	logger.InfoLogger().Printf("Kernel location: %s", kernel_local)
+	logger.InfoLogger("Kernel location: %s", kernel_local)
 
 	return &instance_path
 }
 
 func getUnikernelURL(position int, code string) string {
 	addr := strings.Split(code, ",")
-	logger.InfoLogger().Printf("%v", addr)
+	logger.InfoLogger("%v", addr)
 	if position >= len(addr) {
 		return ""
 	}
@@ -380,9 +380,9 @@ func (r *UnikernelRuntime) VirtualMachineCreationRoutine(
 		defer r.channelLock.Unlock()
 		r.killQueue[hostname] = nil
 		if err := os.RemoveAll(inst_path + instance); err != nil {
-			logger.InfoLogger().Printf("Unable to remove instance data: %v", err)
+			logger.InfoLogger("Unable to remove instance data: %v", err)
 		}
-		logger.InfoLogger().Printf("Removing Instance data -- ")
+		logger.InfoLogger("Removing Instance data -- ")
 	}
 
 	for i, a := range service.Architectures {
@@ -392,12 +392,12 @@ func (r *UnikernelRuntime) VirtualMachineCreationRoutine(
 	}
 
 	if kernelImage == "" {
-		logger.InfoLogger().Printf("Failed to find kernel/architecture pair.")
+		logger.InfoLogger("Failed to find kernel/architecture pair.")
 	}
 
 	kernelPath := GetKernelImage(kernelImage, hostname, service.Sname)
 	if kernelPath == nil {
-		logger.InfoLogger().Println("Failed to get Kernel image")
+		logger.InfoLogger("Failed to get Kernel image")
 		revert(fmt.Errorf("unable to create kernel path"), hostname)
 		return
 	}
@@ -411,7 +411,7 @@ func (r *UnikernelRuntime) VirtualMachineCreationRoutine(
 		//Use Overlay Network to configure network
 		err := requests.CreateNetworkNamespaceForUnikernel(service.Sname, service.Instance, service.Ports)
 		if err != nil {
-			logger.InfoLogger().Printf("Network creation for Unikernel failed: %v\n", err)
+			logger.InfoLogger("Network creation for Unikernel failed: %v\n", err)
 			revert(err, hostname)
 			return
 		}
@@ -422,22 +422,22 @@ func (r *UnikernelRuntime) VirtualMachineCreationRoutine(
 	//Generate the command to start Qemu with
 	command, args, err := qemuConfig.GenerateArgs(r)
 	if err != nil {
-		logger.ErrorLogger().Printf("Failed to start qemu: %v", err)
+		logger.ErrorLogger("Failed to start qemu: %v", err)
 		revert(err, hostname)
 		return
 	}
 
 	qemuCmd = exec.Command(command, args...)
 
-	logger.InfoLogger().Printf("Unikernel starting command: %s", qemuCmd.String())
+	logger.InfoLogger("Unikernel starting command: %s", qemuCmd.String())
 
 	err = qemuCmd.Start()
 	if err != nil {
-		logger.ErrorLogger().Printf("Failed to start qemu: %v", err)
+		logger.ErrorLogger("Failed to start qemu: %v", err)
 		revert(err, hostname)
 		return
 	}
-	logger.InfoLogger().Println("Unikernel started")
+	logger.InfoLogger("Unikernel started")
 
 	exitStatusQemu := make(chan int)
 
@@ -445,10 +445,10 @@ func (r *UnikernelRuntime) VirtualMachineCreationRoutine(
 		err = qemuCmd.Wait()
 		if err != nil {
 			if e, ok := err.(*exec.ExitError); ok {
-				logger.InfoLogger().Printf("Qemu exited with code %d and error %s", e.ExitCode(), string(e.Stderr))
+				logger.InfoLogger("Qemu exited with code %d and error %s", e.ExitCode(), string(e.Stderr))
 				status <- e.ExitCode()
 			} else {
-				logger.InfoLogger().Printf("Unexpected error occured %v", err)
+				logger.InfoLogger("Unexpected error occured %v", err)
 				status <- -1
 			}
 		} else {
@@ -469,16 +469,16 @@ func (r *UnikernelRuntime) VirtualMachineCreationRoutine(
 		conn, err := net.DialTimeout("unix", socketPath, 2*time.Second)
 
 		if errors.Is(err, os.ErrNotExist) {
-			//logger.InfoLogger().Printf("Waiting: %v", err)
+			//logger.InfoLogger("Waiting: %v", err)
 			time.Sleep(10 * time.Millisecond)
 		} else if err != nil {
 			if !strings.HasSuffix(err.Error(), ": connection refused") {
-				logger.InfoLogger().Printf("Something went wrong while starting Qemu %v", err)
+				logger.InfoLogger("Something went wrong while starting Qemu %v", err)
 				revert(err, hostname)
 				if model.GetNodeInfo().Overlay {
 					err = requests.DeleteNamespaceForUnikernel(service.Sname, service.Instance)
 					if err != nil {
-						logger.InfoLogger().Printf("Unable to undeploy %s's network: %v", hostname, err)
+						logger.InfoLogger("Unable to undeploy %s's network: %v", hostname, err)
 					}
 				}
 				if qemuCmd.Process != nil {
@@ -486,7 +486,7 @@ func (r *UnikernelRuntime) VirtualMachineCreationRoutine(
 				}
 				return
 			}
-			//logger.InfoLogger().Printf("Waiting: %v", err)
+			//logger.InfoLogger("Waiting: %v", err)
 
 		} else {
 			conn.Close() //nolint:errcheck // Ignore error check for close
@@ -495,15 +495,15 @@ func (r *UnikernelRuntime) VirtualMachineCreationRoutine(
 
 	}
 
-	logger.InfoLogger().Printf("Trying to connec to to %s", socketPath)
+	logger.InfoLogger("Trying to connec to to %s", socketPath)
 	qemuMonitor, err = qmp.NewSocketMonitor("unix", socketPath, 2*time.Second)
 	if err != nil {
-		logger.InfoLogger().Printf("Failed to Create connection to QMP: %v\n", err)
+		logger.InfoLogger("Failed to Create connection to QMP: %v\n", err)
 		revert(err, hostname)
 		if model.GetNodeInfo().Overlay {
 			err = requests.DeleteNamespaceForUnikernel(service.Sname, service.Instance)
 			if err != nil {
-				logger.InfoLogger().Printf("Unable to undeploy %s's network: %v", hostname, err)
+				logger.InfoLogger("Unable to undeploy %s's network: %v", hostname, err)
 			}
 		}
 		//Kill the qemu process because of no qmp connectivity
@@ -519,21 +519,21 @@ func (r *UnikernelRuntime) VirtualMachineCreationRoutine(
 	r.channelLock.Unlock()
 
 	defer func(monitor *qmp.SocketMonitor) {
-		logger.InfoLogger().Printf("Trying to kill VM %s", hostname)
+		logger.InfoLogger("Trying to kill VM %s", hostname)
 		//There is no guaranteed answer for the quit Command
 		cmd := []byte(`{"execute": "quit"}`)
 		err := monitor.Connect()
 
 		if err != nil {
-			logger.InfoLogger().Printf("Failed to connect to qmp: %v", err)
+			logger.InfoLogger("Failed to connect to qmp: %v", err)
 		}
 		_, err = monitor.Run(cmd)
 		if err != nil {
-			logger.InfoLogger().Printf("Failed to close qemu: %v\n", err)
+			logger.InfoLogger("Failed to close qemu: %v\n", err)
 		}
 		err = monitor.Disconnect()
 		if err != nil {
-			logger.InfoLogger().Printf("Failed to close connection (expected): %v", err)
+			logger.InfoLogger("Failed to close connection (expected): %v", err)
 		}
 
 		r.channelLock.Lock()
@@ -545,14 +545,14 @@ func (r *UnikernelRuntime) VirtualMachineCreationRoutine(
 		if model.GetNodeInfo().Overlay {
 			err = requests.DeleteNamespaceForUnikernel(service.Sname, service.Instance)
 			if err != nil {
-				logger.InfoLogger().Printf("Unable to undeploy %s's network: %v", hostname, err)
+				logger.InfoLogger("Unable to undeploy %s's network: %v", hostname, err)
 			}
 		}
 		//Delete instance folder
 		if err := os.RemoveAll(inst_path + hostname); err != nil {
-			logger.InfoLogger().Printf("Unable to remove instance data: %v", err)
+			logger.InfoLogger("Unable to remove instance data: %v", err)
 		}
-		logger.InfoLogger().Printf("Removing Instance data %s", inst_path+hostname)
+		logger.InfoLogger("Removing Instance data %s", inst_path+hostname)
 
 		if err != nil {
 			*killChannel <- false
@@ -564,9 +564,9 @@ func (r *UnikernelRuntime) VirtualMachineCreationRoutine(
 	startup <- true
 	select {
 	case return_value := <-exitStatusQemu:
-		logger.InfoLogger().Printf("Received status back from Qemu process %d", return_value)
+		logger.InfoLogger("Received status back from Qemu process %d", return_value)
 	case <-*killChannel:
-		logger.InfoLogger().Printf("Kill channel message received for unikernel")
+		logger.InfoLogger("Kill channel message received for unikernel")
 	}
 	service.Status = model.SERVICE_DEAD
 	statusChangeNotificationHandler(service)
@@ -581,7 +581,7 @@ func (r *UnikernelRuntime) ResourceMonitoring(every time.Duration, notifyHandler
 			//Get CPU and memory stats based on pid
 			sysInfo, err := pidusage.GetStat(domain.qemuProcess.Pid)
 			if err != nil {
-				logger.ErrorLogger().Printf("Unable to fetch task info: %v", err)
+				logger.ErrorLogger("Unable to fetch task info: %v", err)
 				continue
 			}
 			resourceList = append(resourceList, model.Resources{
@@ -640,7 +640,7 @@ func (q *QemuConfiguration) GenerateArgs(r *UnikernelRuntime) (string, []string,
 		//Get the default route for the namespace
 		ip, gw, mask, mac, err := networkutils.DeleteDefaultIpGwMask(*q.NSname)
 		if err != nil {
-			logger.InfoLogger().Printf("Unable to get default route for namespace %s: %v", *q.NSname, err)
+			logger.InfoLogger("Unable to get default route for namespace %s: %v", *q.NSname, err)
 			return "", []string{}, err
 		}
 
@@ -667,7 +667,7 @@ func (q *QemuConfiguration) GenerateArgs(r *UnikernelRuntime) (string, []string,
 	mountpath := fmt.Sprintf("%s/files/", q.Instancepath)
 	_, err := os.Stat(mountpath)
 	if err == nil {
-		logger.InfoLogger().Println("Mounting as folder for unikernel")
+		logger.InfoLogger("Mounting as folder for unikernel")
 
 		//FS backend
 		fsdevarg := fmt.Sprintf("local,security_model=passthrough,id=hvirtio0,path=%s/files", q.Instancepath)
@@ -684,7 +684,7 @@ func (q *QemuConfiguration) GenerateArgs(r *UnikernelRuntime) (string, []string,
 	initramfs := fmt.Sprintf("%s/initramfs.cpio", q.Instancepath)
 	_, err = os.Stat(initramfs)
 	if err == nil {
-		logger.InfoLogger().Println("Mounting .cpio root fs")
+		logger.InfoLogger("Mounting .cpio root fs")
 		//FS backend
 		fsdevarg2 := fmt.Sprintf("local,security_model=passthrough,id=hvirtio1,path=%s/initramfs.cpio", q.Instancepath)
 		args = append(args, "-fsdev", fsdevarg2)

--- a/scheduler/api/api.go
+++ b/scheduler/api/api.go
@@ -51,16 +51,16 @@ func getStatus(c *gin.Context) {
 func calculate(c *gin.Context) {
 	json, err := c.GetRawData()
 	if err != nil {
-		logger.ErrorLogger().Printf("Received bad request: %v", err)
+		logger.ErrorLogger("Received bad request: %v", err)
 		c.Status(http.StatusBadRequest)
 	}
 
 	task := asynq.NewTask(TaskTypeScheduler, json)
 	info, err := asynqClient.Enqueue(task)
 	if err != nil {
-		logger.ErrorLogger().Printf("Task enqueue error: %v", err)
+		logger.ErrorLogger("Task enqueue error: %v", err)
 		c.Status(http.StatusInternalServerError)
 	}
-	logger.InfoLogger().Printf("Task enqueued: ID=%s, Type=%s, Queue=%s, Payload=%s",
+	logger.InfoLogger("Task enqueued: ID=%s, Type=%s, Queue=%s, Payload=%s",
 		info.ID, info.Type, info.Queue, string(info.Payload))
 }

--- a/scheduler/calculate/schedulers/bestCpuMemFit/calculate.go
+++ b/scheduler/calculate/schedulers/bestCpuMemFit/calculate.go
@@ -46,7 +46,7 @@ func (r CpuMemResources) GetId() string {
 func (r CpuMemResources) ResourceConstraints() map[string]string {
 	var constraints = make(map[string]string)
 	for _, constraint := range r.Constraints {
-		logger.DebugLogger().Printf("Constraint: %+v", constraint)
+		logger.DebugLogger("Constraint: %+v", constraint)
 		if constraint.Type == "direct" {
 			var c string
 			if Plane == "cluster" {
@@ -181,7 +181,7 @@ func (a BestCpuMemFit) Calculate(job CpuMemResources, candidates []CpuMemResourc
 func filterRequirements(job CpuMemResources, candidates []CpuMemResources) []CpuMemResources {
 	filteredCandidates := make([]CpuMemResources, 0, len(candidates))
 	for _, candidate := range candidates {
-		logger.DebugLogger().Printf("Filtering candidate: %v", candidate)
+		logger.DebugLogger("Filtering candidate: %v", candidate)
 		if slices.Contains(candidate.Virtualization, job.Virtualization[0]) {
 			if candidate.AvailableCPU >= job.AvailableCPU {
 				if candidate.AvailableMem >= job.AvailableMem {
@@ -203,7 +203,7 @@ func hasRequiredCSIDrivers(job CpuMemResources, candidate CpuMemResources) bool 
 			continue
 		}
 		if !slices.Contains(candidate.CSIDrivers, vol.CSIDriver) {
-			logger.DebugLogger().Printf(
+			logger.DebugLogger(
 				"Candidate %s does not have required CSI driver %s (available: %v)",
 				candidate.Id, vol.CSIDriver, candidate.CSIDrivers,
 			)

--- a/scheduler/calculate/schedulers/rootRandom/calculate.go
+++ b/scheduler/calculate/schedulers/rootRandom/calculate.go
@@ -30,7 +30,7 @@ func (r RandomResources) GetId() string {
 func (r RandomResources) ResourceConstraints() map[string]string {
 	var constraints = make(map[string]string)
 	for _, constraint := range r.Constraints {
-		logger.DebugLogger().Printf("Constraint: %+v", constraint)
+		logger.DebugLogger("Constraint: %+v", constraint)
 		if constraint.Type == "direct" {
 			constraints["cluster_name"] = constraint.Cluster
 			constraints["node_name"] = constraint.Node
@@ -109,7 +109,7 @@ func (a BestCpuMemFit) Calculate(job RandomResources, candidates []RandomResourc
 func filterRequirements(job RandomResources, candidates []RandomResources) []RandomResources {
 	filteredCandidates := make([]RandomResources, 0, len(candidates))
 	for _, candidate := range candidates {
-		logger.DebugLogger().Printf("Filtering candidate: %v", candidate)
+		logger.DebugLogger("Filtering candidate: %v", candidate)
 		if slices.Contains(candidate.Virtualization, job.Virtualization[0]) {
 			if candidate.AvailableCPU >= job.AvailableCPU {
 				if candidate.AvailableMem >= job.AvailableMem {

--- a/scheduler/calculate/scheduling.go
+++ b/scheduler/calculate/scheduling.go
@@ -43,7 +43,7 @@ func getInterestedResources[T interfaces.ResourceList](jobData T) []string {
 		interestedResources = append(interestedResources, name)
 	}
 
-	logger.DebugLogger().Printf("Interested resources: %v", interestedResources)
+	logger.DebugLogger("Interested resources: %v", interestedResources)
 	interestedResourcesCache.Store(t, interestedResources)
 	return interestedResources
 }
@@ -55,19 +55,19 @@ func PerformSchedulingRequest[T interfaces.ResourceList](job T, algorithm interf
 	if err != nil {
 		return err
 	}
-	logger.DebugLogger().Printf("Available Resources: %v", data)
+	logger.DebugLogger("Available Resources: %v", data)
 
 	placementCandidate, err := algorithm.Calculate(job, data)
 	if err != nil {
 		var schedulingError interfaces.SchedulingError
 		if errors.As(err, &schedulingError) {
-			logger.ErrorLogger().Printf("Scheduling failed: Sending status %v to manager", err)
+			logger.ErrorLogger("Scheduling failed: Sending status %v to manager", err)
 			err = manager.Deploy(job.GetId(), schedulingError.Error(), false)
 		}
 		return err
 	}
 
-	logger.InfoLogger().Printf("Scheduled job %s to candidate %s", job.GetId(), placementCandidate.GetId())
+	logger.InfoLogger("Scheduled job %s to candidate %s", job.GetId(), placementCandidate.GetId())
 	err = manager.Deploy(job.GetId(), placementCandidate.GetId(), true)
 
 	return err

--- a/scheduler/cmd/tasks.go
+++ b/scheduler/cmd/tasks.go
@@ -39,16 +39,16 @@ func scheduleRequestHandler(ctx context.Context, t *asynq.Task) error {
 	var algorithm A
 	var jobData = algorithm.JobData()
 
-	logger.DebugLogger().Printf("Received payload: %v", string(t.Payload()))
+	logger.DebugLogger("Received payload: %v", string(t.Payload()))
 	err := json.Unmarshal(t.Payload(), &jobData)
 	if err != nil {
-		logger.ErrorLogger().Printf("Could not unmarshal job data: %v", err)
+		logger.ErrorLogger("Could not unmarshal job data: %v", err)
 		return err
 	}
-	logger.DebugLogger().Printf("Received job data: %v", jobData)
+	logger.DebugLogger("Received job data: %v", jobData)
 	err = calculate.PerformSchedulingRequest(jobData, algorithm)
 	if err != nil {
-		logger.ErrorLogger().Printf("Could not Schedule job: %v", err)
+		logger.ErrorLogger("Could not Schedule job: %v", err)
 	}
 	return err
 }

--- a/scheduler/logger/logger.go
+++ b/scheduler/logger/logger.go
@@ -1,44 +1,36 @@
 package logger
 
 import (
-	"io"
-	"log"
+	"fmt"
+	"log/slog"
 	"os"
-	"sync"
 )
 
-var infoLogger *log.Logger
-var errorLogger *log.Logger
-var debugLogger *log.Logger
-var infoOnce sync.Once
-var errorOnce sync.Once
-var debugOnce sync.Once
-var debugMode = false
-
+// SetDebugMode enables debug level logging by setting the default slog logger
+// to DEBUG level, which allows DebugLogger messages to be output.
 func SetDebugMode() {
-	debugMode = true
+	slog.SetDefault(slog.New(slog.NewTextHandler(os.Stdout, &slog.HandlerOptions{
+		Level: slog.LevelDebug,
+	})))
 }
 
-func InfoLogger() *log.Logger {
-	infoOnce.Do(func() {
-		infoLogger = log.New(os.Stdout, "INFO-", log.Ldate|log.Ltime|log.Lshortfile)
-	})
-	return infoLogger
+// InfoLogger logs an info level message with the given format and arguments
+func InfoLogger(format string, args ...any) {
+	slog.Info(fmt.Sprintf(format, args...))
 }
 
-func ErrorLogger() *log.Logger {
-	errorOnce.Do(func() {
-		errorLogger = log.New(os.Stderr, "ERROR-", log.Ldate|log.Ltime|log.Lshortfile)
-	})
-	return errorLogger
+// WarnLogger logs a warning level message with the given format and arguments
+func WarnLogger(format string, args ...any) {
+	slog.Warn(fmt.Sprintf(format, args...))
 }
 
-func DebugLogger() *log.Logger {
-	debugOnce.Do(func() {
-		debugLogger = log.New(os.Stdout, "DEBUG-", log.Ldate|log.Ltime|log.Lshortfile)
-		if !debugMode {
-			debugLogger.SetOutput(io.Discard)
-		}
-	})
-	return debugLogger
+// ErrorLogger logs an error level message with the given format and arguments
+func ErrorLogger(format string, args ...any) {
+	slog.Error(fmt.Sprintf(format, args...))
+}
+
+// DebugLogger logs a debug level message with the given format and arguments.
+// Messages are only output if the slog default logger's level is set to DEBUG
+func DebugLogger(format string, args ...any) {
+	slog.Debug(fmt.Sprintf(format, args...))
 }

--- a/scheduler/logger/logger_test.go
+++ b/scheduler/logger/logger_test.go
@@ -1,0 +1,112 @@
+package logger
+
+import (
+	"bytes"
+	"log/slog"
+	"strings"
+	"testing"
+)
+
+// TestDebugMode verifies that DebugLogger respects the debug level setting
+func TestDebugMode(t *testing.T) {
+	// Save original default logger
+	original := slog.Default()
+	defer slog.SetDefault(original)
+
+	// Test 1: At INFO level, DebugLogger should not output
+	var buf1 bytes.Buffer
+	handler1 := slog.NewTextHandler(&buf1, &slog.HandlerOptions{
+		Level: slog.LevelInfo,
+	})
+	logger1 := slog.New(handler1)
+
+	slog.SetDefault(logger1)
+
+	DebugLogger("should not appear")
+
+	if strings.Contains(buf1.String(), "should not appear") {
+		t.Error("DebugLogger should not output at INFO level")
+	}
+
+	// Test 2: At DEBUG level, DebugLogger should output
+	var buf2 bytes.Buffer
+	handler2 := slog.NewTextHandler(&buf2, &slog.HandlerOptions{
+		Level: slog.LevelDebug,
+	})
+	logger2 := slog.New(handler2)
+
+	slog.SetDefault(logger2)
+	DebugLogger("should appear")
+
+	if !strings.Contains(buf2.String(), "should appear") {
+		t.Error("DebugLogger should output at DEBUG level")
+	}
+}
+
+// TestSetDebugMode verifies that SetDebugMode works without panicking
+func TestSetDebugMode(t *testing.T) {
+	// Save original default logger
+	original := slog.Default()
+	defer slog.SetDefault(original)
+
+	// Set up a logger at INFO level
+	var buf1 bytes.Buffer
+	handler1 := slog.NewTextHandler(&buf1, &slog.HandlerOptions{
+		Level: slog.LevelInfo,
+	})
+	logger1 := slog.New(handler1)
+	slog.SetDefault(logger1)
+
+	// Debug should not appear at INFO level
+	DebugLogger("before SetDebugMode")
+	if strings.Contains(buf1.String(), "before SetDebugMode") {
+		t.Error("DebugLogger should not output before SetDebugMode")
+	}
+
+	// Call SetDebugMode - this creates a new default logger with DEBUG level
+	// Note: SetDebugMode writes to os.Stdout, so we can't capture it in a buffer
+	// But we can verify it doesn't panic
+	SetDebugMode()
+
+	// Verify SetDebugMode completed without panic (we got here)
+	// The actual debug output goes to os.Stdout which is expected
+
+	// Restore
+	slog.SetDefault(original)
+}
+
+// TestLoggerFunctions tests that all logger functions work without panicking
+func TestLoggerFunctions(t *testing.T) {
+	// Save original default logger
+	original := slog.Default()
+	defer slog.SetDefault(original)
+
+	// Create a test logger that writes to our buffer
+	var buf bytes.Buffer
+	testHandler := slog.NewTextHandler(&buf, &slog.HandlerOptions{Level: slog.LevelDebug})
+	testLogger := slog.New(testHandler)
+
+	// Temporarily replace the default logger
+	slog.SetDefault(testLogger)
+
+	// Test all functions - they should not panic
+	InfoLogger("info test: %s", "arg1")
+	WarnLogger("warn test: %s", "arg2")
+	ErrorLogger("error test: %s", "arg3")
+	DebugLogger("debug test: %s", "arg4")
+
+	// Verify output contains our messages
+	output := buf.String()
+	if !strings.Contains(output, "info test: arg1") {
+		t.Errorf("Expected info message in output, got: %s", output)
+	}
+	if !strings.Contains(output, "warn test: arg2") {
+		t.Errorf("Expected warn message in output, got: %s", output)
+	}
+	if !strings.Contains(output, "error test: arg3") {
+		t.Errorf("Expected error message in output, got: %s", output)
+	}
+	if !strings.Contains(output, "debug test: arg4") {
+		t.Errorf("Expected debug message in output, got: %s", output)
+	}
+}

--- a/scheduler/requests/manager/managerRequests.go
+++ b/scheduler/requests/manager/managerRequests.go
@@ -40,25 +40,25 @@ func Deploy(jobId string, result string, success bool) error {
 		req := deploymentRequest{jobId, result}
 		payload, err = json.Marshal(req)
 		if err != nil {
-			logger.ErrorLogger().Println("Could not marshal deployment request")
+			logger.ErrorLogger("Could not marshal deployment request")
 			return err
 		}
 	} else {
 		req := deploymentFailedRequest{jobId, result}
 		payload, err = json.Marshal(req)
 		if err != nil {
-			logger.ErrorLogger().Println("Could not marshal deployment request")
+			logger.ErrorLogger("Could not marshal deployment request")
 			return err
 		}
 	}
 
 	resp, err := http.Post(url, "application/json", bytes.NewBuffer(payload))
 	if err != nil {
-		logger.ErrorLogger().Println("Could not send deployment request")
+		logger.ErrorLogger("Could not send deployment request")
 		return err
 	}
 
-	logger.DebugLogger().Printf("Deployment request %s to url %s", string(payload), url)
+	logger.DebugLogger("Deployment request %s to url %s", string(payload), url)
 	err = resp.Body.Close()
 	if err != nil {
 		return err

--- a/scheduler/requests/resource/resourceAbstractorRequests.go
+++ b/scheduler/requests/resource/resourceAbstractorRequests.go
@@ -68,29 +68,29 @@ func formatInterestedResources(interestedResources []string) string {
 
 func AvailableResources[T interfaces.ResourceList](data *[]T, requestParameters map[string]string, interestedResources []string) error {
 	url := fmt.Sprintf("%s://%s:%s%s/%s", PROTOCOL, RESOURCE_ABSTRACTOR_URL, RESOURCE_ABSTRACTOR_PORT, RESOURCES, formatQuery(requestParameters, interestedResources))
-	logger.DebugLogger().Printf("Request URL: %v", url)
+	logger.DebugLogger("Request URL: %v", url)
 
 	resp, err := http.Get(url)
 	if err != nil {
-		logger.ErrorLogger().Println("Error fetching resources")
+		logger.ErrorLogger("Error fetching resources")
 		return err
 	}
 	defer func(Body io.ReadCloser) {
 		err := Body.Close()
 		if err != nil {
-			logger.ErrorLogger().Println("Error closing body")
+			logger.ErrorLogger("Error closing body")
 		}
 	}(resp.Body)
 
 	body, err := io.ReadAll(resp.Body)
 	if err != nil {
-		logger.ErrorLogger().Println("Error reading body")
+		logger.ErrorLogger("Error reading body")
 		return err
 	}
 
 	err = json.Unmarshal(body, data)
 	if err != nil {
-		logger.ErrorLogger().Println("Error unmarshalling body")
+		logger.ErrorLogger("Error unmarshalling body")
 		return err
 	}
 


### PR DESCRIPTION
Closes #543. This pull request replaces the current logging functionality with `log/slog`.
I have opted to keep the abstraction from the logger package in case we would want to make changes to the logging logic in the future without changing the API again. Of course, we can discuss this further.

Therefore, at call sites:

```go

logger.InfoLogger().Printf("deploying %s", name)
```
becomes:

```go

logger.InfoLogger("deploying %s", name)
```

Also introduced a new API for fatal errors, that logs and exits: 

```go
logger.FatalErrorLogger("fatal error")
```

All the module functions now slog in the implementation.

The debug toggle and fatal error behavior are covered by some unit tests.