### PR TITLE
fix: return the SLA validation error from the SLA POST endpoints

### DIFF
--- a/root_orchestrator/system-manager-python/blueprints/applications_blueprints.py
+++ b/root_orchestrator/system-manager-python/blueprints/applications_blueprints.py
@@ -96,7 +96,7 @@ class CreateApplicationController(Resource):
         current_user = get_jwt_identity()
         result, code = register_app(data, current_user)
         if code != 200:
-            abort(code, description=result)
+            abort(code, message=result["message"])
 
         # TODO(ME): Frontend should be able to handle the _id being a string and not an object.
         for i in range(len(result)):

--- a/root_orchestrator/system-manager-python/blueprints/services_blueprints.py
+++ b/root_orchestrator/system-manager-python/blueprints/services_blueprints.py
@@ -112,14 +112,14 @@ class ServiceControllerPost(MethodView):
             try:
                 username = get_jwt_auth_identity()
                 result, status = service_management.create_services_of_app(username, data)
-                if status != 200:
-                    abort(status, result)
-                return result
             except Exception as e:
                 logging.log(logging.ERROR, e)
-                abort(400, {"message": "The given SLA was not formatted correctly"})
+                abort(400, message="The given SLA was not formatted correctly")
+            if status != 200:
+                abort(status, message=result["message"])
+            return result
         logging.log(logging.ERROR, "POST service no data found")
-        abort(404, {"message": "/api/deploy request without a yaml file\n"})
+        abort(404, message="/api/deploy request without a yaml file\n")
 
 
 @servicesblp.route("/<appid>")

--- a/root_orchestrator/system-manager-python/services/application_management.py
+++ b/root_orchestrator/system-manager-python/services/application_management.py
@@ -20,7 +20,7 @@ def register_app(applications, userid):
     try:
         parse_sla_json(applications)
     except SLAFormatError as e:
-        return {"message": e}, 422
+        return {"message": str(e)}, 422
 
     for application in applications["applications"]:
         if app_operations.get_app_by_name_and_namespace(

--- a/root_orchestrator/system-manager-python/services/service_management.py
+++ b/root_orchestrator/system-manager-python/services/service_management.py
@@ -43,7 +43,7 @@ def create_services_of_app(username, data, force=False):
         parse_sla_json(data)
     except SLAFormatError as e:
         logging.log(logging.ERROR, e)
-        return {"message": e}, 422
+        return {"message": str(e)}, 422
 
     app_id = data.get("applications")[0]["applicationID"]
     last_service_id = ""

--- a/root_orchestrator/system-manager-python/tests/blueprints_test.py
+++ b/root_orchestrator/system-manager-python/tests/blueprints_test.py
@@ -1,0 +1,74 @@
+import json
+import pathlib
+from unittest.mock import patch
+
+import pytest
+from flask import Flask
+from flask_smorest import Api
+
+TEST_SLAS_PATH = pathlib.Path.cwd() / "tests" / "service_level_agreements"
+
+
+@pytest.fixture
+def client():
+    # Imported here rather than at module level so that this file, which pytest
+    # collects before services_test.py, does not become the first importer of
+    # services.service_management and bind it to the wrong net_plugin mock.
+    from blueprints.applications_blueprints import applicationblp
+    from blueprints.services_blueprints import serviceblp
+
+    app = Flask(__name__)
+    app.config["API_TITLE"] = "test"
+    app.config["API_VERSION"] = "v1"
+    app.config["OPENAPI_VERSION"] = "3.0.2"
+    api = Api(app)
+    api.register_blueprint(serviceblp)
+    api.register_blueprint(applicationblp)
+    return app.test_client()
+
+
+@pytest.fixture
+def flawed_sla():
+    with open(TEST_SLAS_PATH / "sla_flawed_5.json", "r") as f:
+        return json.load(f)
+
+
+def rejected_microservice_name(sla):
+    return sla["applications"][0]["microservices"][0]["microservice_name"]
+
+
+def test_post_service_returns_the_sla_validation_error(client, flawed_sla):
+    # /api/service/ is guarded by the repo's own jwt_auth_required wrapper.
+    with (
+        patch("roles.securityUtils.verify_jwt_in_request"),
+        patch("roles.securityUtils.get_jwt", return_value={}),
+        patch("blueprints.services_blueprints.get_jwt_auth_identity", return_value="Admin"),
+    ):
+        response = client.post("/api/service/", json=flawed_sla)
+
+    assert response.status_code == 422
+    assert rejected_microservice_name(flawed_sla) in response.get_json()["message"]
+
+
+def test_post_service_without_a_body_says_so(client):
+    with (
+        patch("roles.securityUtils.verify_jwt_in_request"),
+        patch("roles.securityUtils.get_jwt", return_value={}),
+        patch("blueprints.services_blueprints.get_jwt_auth_identity", return_value="Admin"),
+    ):
+        response = client.post("/api/service/", json={})
+
+    assert response.status_code == 404
+    assert "without a yaml file" in response.get_json()["message"]
+
+
+def test_post_application_returns_the_sla_validation_error(client, flawed_sla):
+    # /api/application/ is guarded by flask_jwt_extended's jwt_required directly.
+    with (
+        patch("flask_jwt_extended.view_decorators.verify_jwt_in_request"),
+        patch("blueprints.applications_blueprints.get_jwt_identity", return_value="Admin"),
+    ):
+        response = client.post("/api/application/", json=flawed_sla)
+
+    assert response.status_code == 422
+    assert rejected_microservice_name(flawed_sla) in response.get_json()["message"]


### PR DESCRIPTION
Closes #171.

## The problem

Posting an SLA that fails validation never tells you what was wrong. With an SLA whose `microservice_name` is `test.special.char`:

```
POST /api/service/       ->  400 {"code": 400, "status": "Bad Request"}
POST /api/application/   ->  422 {"code": 422, "status": "Unprocessable Entity"}
```

The validator already produces the exact reason, and `create_services_of_app` / `register_app` already return it with the right status code. Three separate things throw it away on the way to the response.

**1. The handler catches its own `abort()`.** In `ServiceControllerPost.post`:

```python
try:
    ...
    result, status = service_management.create_services_of_app(username, data)
    if status != 200:
        abort(status, result)     # raises a werkzeug HTTPException
    return result
except Exception as e:            # ...which is an Exception, so this catches it
    logging.log(logging.ERROR, e)
    abort(400, {"message": "The given SLA was not formatted correctly"})
```

`flask_smorest.abort` raises an `HTTPException`, so the broad handler swallows the abort it just made and replaces every failure with a hardcoded 400. That is why the 422 surfaces as a 400.

**2. The payload is passed positionally.** `flask_smorest.abort` is `abort(http_status_code, exc=None, **kwargs)`, and its error handler only renders `error.data["message"]`, which comes from `**kwargs`. `abort(status, result)` and `abort(code, description=result)` both bind the payload to `exc` and drop it. That is why even the correct 422 from `/api/application/` arrives with no `message` field.

**3. The message is an exception object.** Both service functions return `{"message": e}` where `e` is an `SLAFormatError`. That is not JSON-serializable, so fixing 1 and 2 alone turns the response into a 500. `str(e)` rather than `e.message`, because `SLAFormatError.message` is the generic class attribute this issue is complaining about, and because `v2_validator.validate_json_v2` has an `except ValueError as err: return err` branch that also stores an exception rather than a string.

## The fix

- `services_blueprints.py` - narrow the `try` to the call itself so `abort()` is no longer inside it, and pass `message=`. I moved code rather than adding `except HTTPException: raise`, which would leave the same trap in place for the next non-HTTP raise added inside that block.
- `applications_blueprints.py` - `description=` is not a key flask-smorest renders; use `message=`.
- `service_management.py` / `application_management.py` - `str(e)`, so the validator's text survives serialization.

Every exit from `ServiceControllerPost.post` now carries its message, including the no-body 404 three lines down, which had the same positional-argument bug:

```
POST /api/service/       ->  422 {"code": 422, "message": "'test.special.char' does not match '^[a-zA-Z0-9]{1,30}$'", "status": "Unprocessable Entity"}
POST /api/application/   ->  422 {"code": 422, "message": "'test.special.char' does not match '^[a-zA-Z0-9]{1,30}$'", "status": "Unprocessable Entity"}
POST /api/service/ {}    ->  404 {"code": 404, "message": "/api/deploy request without a yaml file\n", "status": "Not Found"}
```

Only `err.message` from jsonschema reaches the body, so no schema dump leaks out.

## Tests

`tests/blueprints_test.py` is new, and is the first test here that goes through a Flask route. It has to be, for defect 2: that one lives inside flask-smorest's error renderer, so calling the view under a request context would never exercise it. `Api(app)` is the mechanism under test, not fixture ceremony.

The three cases post `tests/service_level_agreements/sla_flawed_5.json`, an existing fixture that `sla_test.py` already pins as raising `SLAFormatError`, and an empty body. I reverted each of the five code changes in isolation to confirm the matching test goes red.

The blueprint imports sit inside the `client` fixture on purpose. pytest collects this file before `services_test.py`, and a module-level import would make it the first importer of `services.service_management`, binding it to the wrong `net_plugin` mock and breaking `services_test.py`'s `assert_called_with`.

Ran on Python 3.10 against the pinned `requirements.txt`: 24 passed. The seven pre-existing `services_test.py` failures remain, all of which need the `resource_abstractor` container that CI starts and I could not run locally. `ruff 0.15.22 check` and `ruff 0.15.22 format --check` pass repo-wide.

## Scope

The sibling `abort()` calls in these two files have the same positional-argument bug, 17 of them. #171 names two endpoints, so this PR fixes those and the one remaining exit inside the same method; fixing an arbitrary subset of the rest would ship untested changes. Happy to follow up on them in a separate PR.

One heads-up: #568 and #484 both touch these lines, for structured logging and JSON quoting respectively. Neither changes this behaviour, but whichever lands second will want a small rebase.

I used AI assistance while writing this; the diagnosis, the tests and the toolchain runs above are ones I checked myself.