### PR TITLE
feat: add control-plane metrics collection

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -66,6 +66,9 @@ Root Orchestrator  (1 per deployment)
 | `root_resource_abstractor` | Python/Flask | 11011 | DB abstraction layer over mongo (port 10007). Exposes REST for reading/writing cluster and job resource data. |
 | `jwt_generator` | Go | 10011 | Issues RS256 key pairs. system_manager fetches the public key on startup. |
 | `root_redis` | Redis | 6379 (pw: `rootRedis`) | Job queue (asynq) for root_scheduler. |
+| `root_prometheus` | Prometheus 3.13.2 | 9090 (internal) | Stores Root-host and Root-container metrics locally with 7-day/1-GB retention. |
+| `root_node_exporter` | node_exporter 1.12.1 | 9100 (internal) | Exposes Root-host CPU, memory, filesystem, disk, and network metrics. |
+| `root_cadvisor` | cAdvisor 0.60.5 | 8081 (loopback) | Exposes per-container resources for Oakestra-labelled Root containers and a host-local diagnostic UI. |
 | `grafana` | Grafana | 3000 | Dashboards. |
 | `loki` | Loki | 3100 | Log aggregation. |
 | `alloy` | Grafana Alloy 1.17.0 | 12345 (loopback) | Discovers every Root container, ships stdout/stderr to the Root-local Loki, and exposes its diagnostic UI locally. |
@@ -90,7 +93,9 @@ Root Orchestrator  (1 per deployment)
 | `cluster_addons_manager` | Python | 11201 | Cluster-level addons manager (optional, disable with override-no-addons.yml). |
 | `cluster_addons_monitor` | Python | — | Monitors running addon containers via docker socket at cluster level. |
 | `cluster_addons_dashboard` | Python | 11203 | Cluster addons UI. |
-| `prometheus` | Prometheus | 10009 (→9090) | Scrapes cluster_manager metrics. |
+| `cluster_prometheus` | Prometheus 3.13.2 | 9090 (internal) | Stores Cluster-host, Cluster-container, and cluster_manager metrics locally with 7-day/1-GB retention. |
+| `cluster_node_exporter` | node_exporter 1.12.1 | 9100 (internal) | Exposes Cluster-host CPU, memory, filesystem, disk, and network metrics. |
+| `cluster_cadvisor` | cAdvisor 0.60.5 | 8082 (loopback) | Exposes per-container resources for Oakestra-labelled Cluster containers and a host-local diagnostic UI. |
 | `cluster_grafana` | Grafana | 3001 | Cluster dashboards. |
 | `cluster_loki` | Loki | 3101 | Cluster log aggregation. |
 | `cluster_alloy` | Grafana Alloy 1.17.0 | 12346 (loopback) | Discovers every Cluster container, ships stdout/stderr to that Cluster's local Loki, and exposes its diagnostic UI locally. |
@@ -140,7 +145,7 @@ export OVERRIDE_FILES="override-no-addons.yml,override-network-host.yml"
 | `override-no-network.yml` | Disables the network plugin (root/cluster service managers). |
 | `override-no-addons.yml` | Removes addons subsystem from root. |
 | `override-no-dashboard.yml` | Removes frontend dashboard from root. |
-| `override-no-observe.yml` | Removes Grafana/Loki/Alloy/Prometheus. |
+| `override-no-observe.yml` | Removes Grafana, Loki, Alloy, Prometheus, node_exporter, and cAdvisor. |
 | `override-mosquitto-auth.yml` | Enables MQTT authentication (workers need credentials). |
 | `override-images-only.yml` | Forces pre-built images, skips local builds. |
 | `override-local-service-manager.yml` | Builds service manager from local source. |
@@ -160,7 +165,7 @@ export OVERRIDE_FILES="override-no-addons.yml,override-network-host.yml"
 | Databases | MongoDB 8.0, Redis | — |
 | Messaging | Eclipse Mosquitto 2.0 (MQTT) | — |
 | Networking | oakestra-net (external Go repo) | — |
-| Observability | Grafana, Loki 2.9.2, Alloy 1.17.0, Prometheus | — |
+| Observability | Grafana, Loki 2.9.2, Alloy 1.17.0, Prometheus 3.13.2, node_exporter 1.12.1, cAdvisor 0.60.5 | — |
 | Python logging | structlog 26.1.0 + standard-library bridge | JSON schema v1, stdout only |
 
 ---
@@ -235,6 +240,10 @@ export OAKESTRA_VERSION=develop
 
 - **Host networking breaks container DNS.** When using `override-network-host.yml`, containers can't resolve each other by name — set all env vars to IPs, not container names.
 - **Shared libraries are always local.** Internal Python packages are built from this repo's `libraries/` folder (see the Shared Libraries section); they are not fetched from a remote Git repository. Edit the local library and rebuild. Docker builds use BuildKit/Buildx named contexts, which are already configured in Compose, CI, and VS Code tasks.
+- **Metrics compatibility.** The metrics stack requires rootful Linux Docker Engine 25+ on AMD64 or ARM64. Core Oakestra can run on older supported Docker versions with `override-no-observe.yml`.
+- **Metrics stay local.** Standalone Root and Cluster Prometheus instances store only their host's data. 1-DOC uses one exporter pair and one Prometheus for the shared physical host. cAdvisor container series use `cluster_id` and `compose_service`; host-wide series use `host_scope`.
+- **Host network counters need the host network namespace.** node_exporter has host networking but no host PID namespace or capabilities. Its listener is restricted to the private metrics-network gateway and must not be changed to `0.0.0.0`.
+- **Metrics mounts are sensitive.** cAdvisor receives read-only host and Docker socket mounts. Read-only socket access still exposes privileged daemon metadata, so its diagnostic UI is loopback-only; Prometheus and node_exporter remain internal in normal deployments.
 - **Structured Python logs.** The JSON shape is fixed in `libraries/oakestra_logging`. Use `LOG_LEVEL` only for verbosity and `OAKESTRA_SERVICE_NAME` for the runtime role. Do not log complete request bodies, credentials, users, SLAs, MQTT payloads, or database records.
 - **eventlet monkey-patching.** Both `system_manager` and `cluster_manager` use eventlet. Monkey-patching must happen before Flask/pymongo imports — don't reorder the top of entry-point files.
 - **Scheduler is the same binary for root and cluster** — differentiated only by env vars (`SCHEDULER_TYPE`, Redis URL/password). Keep deployment-specific logic out of the binary.

--- a/SKILLS/troubleshoot-oakestra.md
+++ b/SKILLS/troubleshoot-oakestra.md
@@ -46,8 +46,11 @@ docker compose version 2>/dev/null || docker-compose --version 2>/dev/null
 ```
 
 **Requirements:**
-- Docker Engine ≥ 20.10 (24+ recommended)
+- Docker Engine ≥ 20.10 for the core orchestrator
+- Docker Engine ≥ 25 on rootful Linux when Prometheus, node_exporter, and cAdvisor are enabled
 - Docker Compose plugin v2+ (i.e., `docker compose`, not `docker-compose`)
+
+The metrics stack supports AMD64 and ARM64. On an older or unsupported host, confirm that `override-no-observe.yml` was applied before treating the Docker version as the deployment failure.
 
 **Fix if outdated:**
 ```bash
@@ -93,12 +96,16 @@ done
 
 **Cluster Orchestrator ports:**
 ```bash
-for port in 10003 10107 10108 10110 10100 10101 10105 11012 6479 10009 3001 3101 12346; do
+for port in 10003 10107 10108 10110 10100 10101 10105 11012 6479 3001 3101 12346; do
   ss -tlnp "sport = :$port" 2>/dev/null | grep -v "State" | head -1 && echo "  ^ port $port" || true
 done
 ```
 
 Flag any port occupied by a non-Oakestra process. Common conflict: port 80 occupied by nginx/apache, port 3000 by another Grafana, port 6379 by a system Redis.
+
+Prometheus and node_exporter are internal in normal deployments. cAdvisor is loopback-only on Root/1-DOC port `8081` or standalone Cluster port `8082`. With `override-network-host.yml`, also check Root loopback port `10010` or Cluster loopback port `10009`; none of these endpoints may bind to a non-loopback address.
+
+node_exporter intentionally uses the host network namespace for physical interface counters but must not use the host PID namespace or retain Linux capabilities. Its port 9100 listener must bind only to the configured private metrics-network gateway, never `0.0.0.0`.
 
 ---
 
@@ -117,13 +124,17 @@ For each container, check:
 - `Created` (never started) → dependency failed to start
 
 **Expected containers for Root Orchestrator:**
-`system_manager`, `mongo`, `mongo_net`, `root_service_manager`, `root_redis`, `root_scheduler`, `root_resource_abstractor`, `jwt_generator`, `grafana`, `loki`, `alloy`, `oakestra-frontend-container`
+`system_manager`, `mongo`, `mongo_net`, `root_service_manager`, `root_redis`, `root_scheduler`, `root_resource_abstractor`, `jwt_generator`, `root_prometheus`, `root_node_exporter`, `root_cadvisor`, `grafana`, `loki`, `alloy`, `oakestra-frontend-container`
+
+In 1-DOC, the single shared metrics pipeline is named `prometheus`, `node_exporter`, and `cadvisor` instead of using the standalone Root names.
 
 Optional root containers (if addons enabled):
 `root_addons_manager`, `root_addons_monitor`, `root_addons_dashboard`, `marketplace_manager`
 
 **Expected containers for Cluster Orchestrator:**
-`mqtt`, `cluster_mongo`, `cluster_mongo_net`, `cluster_service_manager`, `cluster_manager`, `cluster_scheduler`, `cluster_resource_abstractor`, `cluster_redis`, `prometheus`, `cluster_grafana`, `cluster_loki`, `cluster_alloy`
+`mqtt`, `cluster_mongo`, `cluster_mongo_net`, `cluster_service_manager`, `cluster_manager`, `cluster_scheduler`, `cluster_resource_abstractor`, `cluster_redis`, `cluster_prometheus`, `cluster_node_exporter`, `cluster_cadvisor`, `cluster_grafana`, `cluster_loki`, `cluster_alloy`
+
+The Prometheus and exporter containers are intentionally absent when `override-no-observe.yml` is active.
 
 Optional cluster containers (if addons enabled):
 `cluster_addons_manager`, `cluster_addons_monitor`, `cluster_addons_dashboard`
@@ -189,6 +200,9 @@ line. If Python application lines are plain text, verify the image version and t
 | `Cluster reachability probe failed` / `cluster not reachable at` (system_manager log) | Root cannot reach `http://CLUSTER_ADDRESS:10100/api/cluster/status` — wrong IP, firewall, or cluster_manager not up |
 | `permission denied` opening `/var/run/docker.sock` (Alloy log) | Alloy cannot discover/read container logs; inspect the socket mount and host permissions |
 | `loki.write` connection refused | The local Loki is not ready, or `LOKI_URL` is wrong for the selected network mode |
+| cAdvisor `permission denied` or missing Docker root | Verify rootful Docker, the read-only socket/host mounts, and `DOCKER_ROOT_DIR`; do not silently enable privileged mode |
+| Prometheus target `DOWN` / `connection refused` | Inspect the relevant Prometheus config and Compose network; host-network Cluster mode must use `prometheus-host.yml` |
+| metrics stack requires Docker Engine 25 | Upgrade Docker or apply `override-no-observe.yml` on that host |
 
 ---
 
@@ -588,8 +602,26 @@ curl -s --connect-timeout 3 "http://localhost:3001/api/health" 2>/dev/null | pyt
 curl -s --connect-timeout 3 "http://localhost:3100/ready" 2>/dev/null || echo "Root Loki not responding on :3100"
 curl -s --connect-timeout 3 "http://localhost:3101/ready" 2>/dev/null || echo "Cluster Loki not responding on :3101"
 
-# Prometheus (cluster)
-curl -s --connect-timeout 3 "http://localhost:10009/-/healthy" 2>/dev/null || echo "Prometheus not responding on :10009"
+# Prometheus is internal. Query whichever local deployment is present.
+for prometheus_container in root_prometheus cluster_prometheus prometheus; do
+  if docker inspect "$prometheus_container" >/dev/null 2>&1; then
+    echo "=== $prometheus_container targets ==="
+    docker exec "$prometheus_container" \
+      promtool query instant http://127.0.0.1:9090 up 2>/dev/null || \
+      echo "$prometheus_container is not ready"
+  fi
+done
+
+# Verify cAdvisor is not privileged and all host bind mounts are read-only.
+for cadvisor_container in root_cadvisor cluster_cadvisor cadvisor; do
+  docker inspect "$cadvisor_container" \
+    --format 'privileged={{.HostConfig.Privileged}}{{range .Mounts}}{{println .Destination "RW=" .RW}}{{end}}' \
+    2>/dev/null || true
+done
+
+# cAdvisor diagnostic UIs and raw metrics (loopback only).
+curl -fsS --connect-timeout 3 -o /dev/null "http://127.0.0.1:8081/metrics" 2>/dev/null || echo "Root/1-DOC cAdvisor not responding on :8081"
+curl -fsS --connect-timeout 3 -o /dev/null "http://127.0.0.1:8082/metrics" 2>/dev/null || echo "Cluster cAdvisor not responding on :8082"
 
 # Alloy diagnostic UIs (loopback only)
 curl -fsS --connect-timeout 3 "http://localhost:12345/-/ready" 2>/dev/null || echo "Root/1-DOC Alloy UI not responding on :12345"

--- a/cluster_orchestrator/config/README.md
+++ b/cluster_orchestrator/config/README.md
@@ -10,6 +10,21 @@ The Cluster identity in Loki's `cluster_id` label is the configured `CLUSTER_NAM
 
 Python services use the versioned JSON contract documented by the shared [`oakestra_logging`](../../libraries/oakestra_logging/) package. Alloy collects these structured records together with raw Go and third-party output.
 
+## Control-plane metrics
+
+Each Cluster also runs a local `cluster_prometheus`, `cluster_node_exporter`, and `cluster_cadvisor`. Prometheus scrapes itself, both exporters, and the existing Cluster Manager metrics endpoint every 15 seconds. node_exporter reports host CPU, memory, filesystem, disk, and network counters. cAdvisor reports the same resource families per Oakestra container, filters out unrelated Docker containers, and maps the trusted Compose labels to `compose_service` and the configured `CLUSTER_NAME` in `cluster_id`. Host-wide series use `host_scope="cluster"`.
+
+node_exporter shares the host network namespace so its network collector sees physical host interfaces rather than only a container `eth0`; it does not share the host PID namespace. Its listener is restricted to the private internal metrics-network gateway, and the process has read-only host mounts, no Linux capabilities, and `no-new-privileges`.
+
+Metrics are retained for at most seven days or 1 GB. Cluster Grafana reaches Prometheus through the provisioned `Prometheus` datasource. cAdvisor's diagnostic UI and raw metrics are available only from the Cluster host at `http://127.0.0.1:8082` and `http://127.0.0.1:8082/metrics`; under the host-network override Prometheus is additionally bound only to `127.0.0.1:10009`. The Root does not scrape these metrics, so every standalone Cluster keeps and displays its own history.
+
+The metrics stack requires rootful Linux Docker Engine 25 or newer on AMD64 or ARM64. Set `DOCKER_ROOT_DIR` for a non-default Docker data directory. The Docker socket and host filesystems are mounted read-only but remain sensitive; keep cAdvisor on loopback and do not expose node_exporter. Use `override-no-observe.yml` on unsupported hosts.
+
+```bash
+docker exec cluster_prometheus promtool query instant http://127.0.0.1:9090 up
+docker exec cluster_prometheus promtool query instant http://127.0.0.1:9090 prometheus_tsdb_head_series
+```
+
 ## Provisioned logs dashboard
 
 Cluster Grafana automatically loads the version-controlled [`[Oakestra] Orchestrator Logs`](./dashboards/logs-dashboard.json) dashboard. Open `http://<cluster-address>:3001` and select it from **Dashboards**. **Source** separates Oakestra services, observability, and data stores; Cluster, Component, Level, Full-line search, and the time picker narrow the Cluster-local history. Keep each query window at 30 days or less: Grafana's generic picker can display longer ranges, but Loki 2.9 rejects a single query longer than its `30d1h` default; inspect older retained history by moving an absolute window of at most 30 days backward. Level matches Alloy's normalized label exactly, with Critical separate from Error and unsupported formats under Unparsed. **Display** defaults to a Compact component/message/event/context summary and can switch to the exact Raw record; formatting happens after filtering and does not modify Loki data. Python fields are accepted only from expected structured services with the schema-v1 identity fields and matching service-to-container identity, while MongoDB, logfmt, Redis, Nginx, scheduler, and legacy parsers are scoped to their known formats. Payload fields, logger names, and message words therefore cannot cause false severity matches. The application `service` field stays in JSON for query-time filtering; `compose_service` is the trusted indexed component. Use **Advanced field filter (LogQL)** with `| json` to query `event`, `logger`, or nested `context` fields without indexing them. Its optional `| logfmt` parser is only for a selected local observability component that emits logfmt. Shared-ID links retain the time range and search the same Oakestra ID in another component; they are correlation shortcuts rather than distributed traces. Use the panel's **Explore** action for the full LogQL editor.

--- a/cluster_orchestrator/config/alerts/grafana-rules.yml
+++ b/cluster_orchestrator/config/alerts/grafana-rules.yml
@@ -25,7 +25,7 @@ groups:
                 (
                   sum by (cluster_id, compose_service) (
                     count_over_time(
-                      {cluster_id=~".+", compose_service=~".+", compose_service!~"^(grafana|cluster_grafana|loki|cluster_loki|alloy|cluster_alloy|prometheus)$", level=~"error|critical"}
+                      {cluster_id=~".+", compose_service=~".+", compose_service!~"^(grafana|cluster_grafana|loki|cluster_loki|alloy|cluster_alloy|prometheus|node_exporter|cadvisor)$", level=~"error|critical"}
                       | json
                       | __error__ = ""
                       | schema_version = 1
@@ -37,7 +37,7 @@ groups:
                 (
                   sum by (cluster_id, compose_service) (
                     count_over_time(
-                      {cluster_id=~".+", compose_service=~".+", compose_service!~"^(grafana|cluster_grafana|loki|cluster_loki|alloy|cluster_alloy|prometheus)$"}
+                      {cluster_id=~".+", compose_service=~".+", compose_service!~"^(grafana|cluster_grafana|loki|cluster_loki|alloy|cluster_alloy|prometheus|node_exporter|cadvisor)$"}
                       !~ `"schema_version"\s*:\s*1\s*[,}]`
                       |~ `(?i:\b(ERROR|FATAL|CRITICAL|EXCEPTION)\b|Traceback \(most recent call last\):|panic:|fatal error:|runtime error:|goroutine [0-9]+ \[|File ".*", line [0-9]+|\.go:[0-9]+ \+0x|\[[EF][0-9])`
                       [2m]

--- a/cluster_orchestrator/config/config.alloy
+++ b/cluster_orchestrator/config/config.alloy
@@ -187,11 +187,11 @@ loki.process "oakestra" {
 		}
 	}
 
-	// Grafana, Loki, Alloy, and Prometheus emit logfmt. Parsing only these known
+	// Grafana, Loki, Alloy, Prometheus, and node_exporter emit logfmt. Parsing only these known
 	// emitters reads the real top-level level field instead of matching text
 	// embedded later in a message or query.
 	stage.match {
-		selector = `{compose_service=~"alloy|cluster_alloy|grafana|cluster_grafana|loki|cluster_loki|prometheus"}`
+		selector = `{compose_service=~"alloy|cluster_alloy|grafana|cluster_grafana|loki|cluster_loki|prometheus|node_exporter"}`
 
 		stage.logfmt {
 			mapping = {

--- a/cluster_orchestrator/config/dashboards/log-statistics-dashboard.json
+++ b/cluster_orchestrator/config/dashboards/log-statistics-dashboard.json
@@ -1120,7 +1120,7 @@
           {
             "selected": false,
             "text": "Observability",
-            "value": "^(alloy|grafana|loki|cluster_alloy|cluster_grafana|cluster_loki|prometheus)$"
+            "value": "^(alloy|grafana|loki|cluster_alloy|cluster_grafana|cluster_loki|prometheus|node_exporter|cadvisor)$"
           },
           {
             "selected": false,
@@ -1133,7 +1133,7 @@
             "value": ".+"
           }
         ],
-        "query": "Oakestra services : ^(system_manager|root_scheduler|root_resource_abstractor|resource_abstractor|root_service_manager|jwt_generator|dashboard|marketplace_manager|root_addons_dashboard|root_addons_manager|root_addons_monitor|addons_dashboard|addons_manager|addons_monitor|cluster_manager|cluster_scheduler|cluster_resource_abstractor|cluster_service_manager|cluster_addons_dashboard|cluster_addons_manager|cluster_addons_monitor|mqtt)$, Observability : ^(alloy|grafana|loki|cluster_alloy|cluster_grafana|cluster_loki|prometheus)$, Data stores : ^(mongo_root|mongo_rootnet|root_redis|redis|mongo_cluster|mongo_clusternet|cluster_redis)$, All containers : .+",
+        "query": "Oakestra services : ^(system_manager|root_scheduler|root_resource_abstractor|resource_abstractor|root_service_manager|jwt_generator|dashboard|marketplace_manager|root_addons_dashboard|root_addons_manager|root_addons_monitor|addons_dashboard|addons_manager|addons_monitor|cluster_manager|cluster_scheduler|cluster_resource_abstractor|cluster_service_manager|cluster_addons_dashboard|cluster_addons_manager|cluster_addons_monitor|mqtt)$, Observability : ^(alloy|grafana|loki|cluster_alloy|cluster_grafana|cluster_loki|prometheus|node_exporter|cadvisor)$, Data stores : ^(mongo_root|mongo_rootnet|root_redis|redis|mongo_cluster|mongo_clusternet|cluster_redis)$, All containers : .+",
         "queryValue": "",
         "skipUrlSync": false,
         "type": "custom"

--- a/cluster_orchestrator/config/dashboards/logs-dashboard.json
+++ b/cluster_orchestrator/config/dashboards/logs-dashboard.json
@@ -191,7 +191,7 @@
           {
             "selected": false,
             "text": "Observability",
-            "value": "^(alloy|grafana|loki|cluster_alloy|cluster_grafana|cluster_loki|prometheus)$"
+            "value": "^(alloy|grafana|loki|cluster_alloy|cluster_grafana|cluster_loki|prometheus|node_exporter|cadvisor)$"
           },
           {
             "selected": false,
@@ -204,7 +204,7 @@
             "value": ".+"
           }
         ],
-        "query": "Oakestra services : ^(system_manager|root_scheduler|root_resource_abstractor|resource_abstractor|root_service_manager|jwt_generator|dashboard|marketplace_manager|root_addons_dashboard|root_addons_manager|root_addons_monitor|addons_dashboard|addons_manager|addons_monitor|cluster_manager|cluster_scheduler|cluster_resource_abstractor|cluster_service_manager|cluster_addons_dashboard|cluster_addons_manager|cluster_addons_monitor|mqtt)$, Observability : ^(alloy|grafana|loki|cluster_alloy|cluster_grafana|cluster_loki|prometheus)$, Data stores : ^(mongo_root|mongo_rootnet|root_redis|redis|mongo_cluster|mongo_clusternet|cluster_redis)$, All containers : .+",
+        "query": "Oakestra services : ^(system_manager|root_scheduler|root_resource_abstractor|resource_abstractor|root_service_manager|jwt_generator|dashboard|marketplace_manager|root_addons_dashboard|root_addons_manager|root_addons_monitor|addons_dashboard|addons_manager|addons_monitor|cluster_manager|cluster_scheduler|cluster_resource_abstractor|cluster_service_manager|cluster_addons_dashboard|cluster_addons_manager|cluster_addons_monitor|mqtt)$, Observability : ^(alloy|grafana|loki|cluster_alloy|cluster_grafana|cluster_loki|prometheus|node_exporter|cadvisor)$, Data stores : ^(mongo_root|mongo_rootnet|root_redis|redis|mongo_cluster|mongo_clusternet|cluster_redis)$, All containers : .+",
         "queryValue": "",
         "skipUrlSync": false,
         "type": "custom"

--- a/cluster_orchestrator/config/grafana-datasources.yml
+++ b/cluster_orchestrator/config/grafana-datasources.yml
@@ -31,3 +31,14 @@ datasources:
           matcherRegex: '\b([a-fA-F0-9]{24})\b'
           url: '/d/oakestra-logs/oakestra-orchestrator-logs?orgId=1&$${__url_time_range}&var-cluster_id=All&var-source_scope=.%2B&var-compose_service=cluster_service_manager&var-level_filter=.%2A&var-search=$${__value.raw}&var-logql_pipeline='
           urlDisplayLabel: "Search this ID in Cluster Service Manager"
+
+  - name: Prometheus
+    type: prometheus
+    uid: Prometheus
+    access: proxy
+    url: $PROMETHEUS_URL
+    editable: true
+    isDefault: false
+    jsonData:
+      httpMethod: POST
+      timeInterval: 15s

--- a/cluster_orchestrator/docker-compose.yml
+++ b/cluster_orchestrator/docker-compose.yml
@@ -192,18 +192,140 @@ services:
 
 
   prometheus:
-    image: prom/prometheus
-    container_name: prometheus
-    hostname: prometheus
+    image: prom/prometheus:v3.13.2-distroless
+    container_name: cluster_prometheus
+    hostname: cluster_prometheus
     labels: *cluster-log-labels
-    ports:
-      - 10009:9090
+    expose:
+      - "9090"
     volumes:
-      - ./prometheus/:/etc/prometheus/
+      - ./prometheus/prometheus.yml:/etc/prometheus/prometheus.yml:ro
+      - cluster_prometheus_data:/prometheus
     command:
-      - '--config.file=/etc/prometheus/prometheus.yml'
+      - --config.file=/etc/prometheus/prometheus.yml
+      - --storage.tsdb.path=/prometheus
+      - --storage.tsdb.retention.time=7d
+      - --storage.tsdb.retention.size=1GB
     depends_on:
       - cluster_manager
+      - node_exporter
+      - cadvisor
+    extra_hosts:
+      - host.metrics.internal=${CLUSTER_METRICS_GATEWAY:-172.30.251.1}
+    networks:
+      - default
+      - metrics
+    read_only: true
+    tmpfs:
+      - /tmp
+    cap_drop:
+      - ALL
+    security_opt:
+      - no-new-privileges:true
+    restart: unless-stopped
+    logging: *default-logging
+
+  node_exporter:
+    image: quay.io/prometheus/node-exporter:v1.12.1
+    container_name: cluster_node_exporter
+    hostname: cluster_node_exporter
+    labels: *cluster-log-labels
+    network_mode: host
+    command:
+      - --path.procfs=/host/proc
+      - --path.sysfs=/host/sys
+      - --path.rootfs=/host
+      - --collector.filesystem.mount-points-exclude=^/(dev|proc|sys|var/lib/docker/.+|var/lib/containers/storage/.+)($$|/)
+      - --web.listen-address=${CLUSTER_METRICS_GATEWAY:-172.30.251.1}:9100
+      - --web.max-requests=5
+    volumes:
+      - type: bind
+        source: /proc
+        target: /host/proc
+        read_only: true
+        bind:
+          create_host_path: false
+      - type: bind
+        source: /sys
+        target: /host/sys
+        read_only: true
+        bind:
+          create_host_path: false
+      - type: bind
+        source: /
+        target: /host
+        read_only: true
+        bind:
+          propagation: rslave
+    read_only: true
+    cap_drop:
+      - ALL
+    security_opt:
+      - no-new-privileges:true
+    restart: unless-stopped
+    logging: *default-logging
+
+  cadvisor:
+    image: ghcr.io/google/cadvisor:v0.60.5
+    container_name: cluster_cadvisor
+    hostname: cluster_cadvisor
+    labels: *cluster-log-labels
+    ports:
+      - "127.0.0.1:8082:8080"
+    command:
+      - --docker_only=true
+      - --store_container_labels=false
+      - --whitelisted_container_labels=com.docker.compose.service,oakestra.cluster.id,oakestra.logging.collector
+      - --enable_metrics=cpu,disk,diskIO,memory,network
+      - --housekeeping_interval=10s
+      - --max_housekeeping_interval=15s
+      - --storage_duration=1m
+    volumes:
+      - type: bind
+        source: /
+        target: /rootfs
+        read_only: true
+        bind:
+          propagation: rslave
+      - type: bind
+        source: /sys
+        target: /sys
+        read_only: true
+        bind:
+          create_host_path: false
+      - type: bind
+        source: /var/run/docker.sock
+        target: /var/run/docker.sock
+        read_only: true
+        bind:
+          create_host_path: false
+      - type: bind
+        source: ${CONTAINERD_SOCKET:-/run/containerd/containerd.sock}
+        target: ${CONTAINERD_SOCKET:-/run/containerd/containerd.sock}
+        read_only: true
+        bind:
+          create_host_path: false
+      - type: bind
+        source: ${DOCKER_ROOT_DIR:-/var/lib/docker}
+        target: ${DOCKER_ROOT_DIR:-/var/lib/docker}
+        read_only: true
+        bind:
+          create_host_path: false
+      - type: bind
+        source: /dev/disk
+        target: /dev/disk
+        read_only: true
+        bind:
+          create_host_path: false
+    read_only: true
+    tmpfs:
+      - /tmp
+    cap_drop:
+      - ALL
+    security_opt:
+      - no-new-privileges:true
+    restart: unless-stopped
+    logging: *default-logging
 
 
   # Observability stack (Grafana, Loki, Alloy)
@@ -215,6 +337,7 @@ services:
     ports:
       - 3001:3000
     environment:
+      - PROMETHEUS_URL=http://cluster_prometheus:9090
       - OAKESTRA_ALERT_CONTACT_POINT=${OAKESTRA_ALERT_CONTACT_POINT:-Oakestra Alert Webhook}
       - OAKESTRA_ALERT_WEBHOOK_URL=${OAKESTRA_ALERT_WEBHOOK_URL:-http://127.0.0.1:65535/oakestra-alerts}
       - OAKESTRA_ALERT_EMAIL_TO=${OAKESTRA_ALERT_EMAIL_TO:-alerts@example.invalid}
@@ -340,7 +463,15 @@ volumes:
     driver: local
   cluster_loki_data:
     driver: local
+  cluster_prometheus_data:
+    driver: local
 
 networks:
   default:
     name: oakestra
+  metrics:
+    internal: true
+    ipam:
+      config:
+        - subnet: ${CLUSTER_METRICS_SUBNET:-172.30.251.0/24}
+          gateway: ${CLUSTER_METRICS_GATEWAY:-172.30.251.1}

--- a/cluster_orchestrator/override-images-only.yml
+++ b/cluster_orchestrator/override-images-only.yml
@@ -28,7 +28,15 @@ services:
     pull_policy: always
 
   prometheus:
-    image: prom/prometheus
+    image: prom/prometheus:v3.13.2-distroless
+    pull_policy: always
+
+  node_exporter:
+    image: quay.io/prometheus/node-exporter:v1.12.1
+    pull_policy: always
+
+  cadvisor:
+    image: ghcr.io/google/cadvisor:v0.60.5
     pull_policy: always
 
   cluster_grafana:

--- a/cluster_orchestrator/override-ipv6-enabled.yml
+++ b/cluster_orchestrator/override-ipv6-enabled.yml
@@ -1,5 +1,3 @@
-version: "3.3"
-
 services:
   mqtt:
     networks:
@@ -50,6 +48,30 @@ services:
       cluster_net:
         ipv4_address: 192.168.129.9
         ipv6_address: 2001:db8:b::9
+
+  cadvisor:
+    networks:
+      cluster_net:
+        ipv4_address: 192.168.129.15
+        ipv6_address: 2001:db8:b::15
+
+  cluster_grafana:
+    networks:
+      cluster_net:
+        ipv4_address: 192.168.129.16
+        ipv6_address: 2001:db8:b::16
+
+  cluster_loki:
+    networks:
+      cluster_net:
+        ipv4_address: 192.168.129.17
+        ipv6_address: 2001:db8:b::17
+
+  cluster_alloy:
+    networks:
+      cluster_net:
+        ipv4_address: 192.168.129.18
+        ipv6_address: 2001:db8:b::18
 
   cluster_resource_abstractor:
     networks:

--- a/cluster_orchestrator/override-network-host.yml
+++ b/cluster_orchestrator/override-network-host.yml
@@ -69,12 +69,19 @@ services:
 
 
   prometheus:
-    network_mode: host
+    ports:
+      - 127.0.0.1:10009:9090
+    volumes:
+      - ./prometheus/prometheus-host.yml:/etc/prometheus/prometheus.yml:ro
+    extra_hosts:
+      - host.docker.internal:host-gateway
 
 
   # Observability stack (Grafana, Loki, Alloy)
   cluster_grafana:
     network_mode: host
+    environment:
+      - PROMETHEUS_URL=http://127.0.0.1:10009
 
   cluster_loki:
     network_mode: host

--- a/cluster_orchestrator/prometheus/prometheus-host.yml
+++ b/cluster_orchestrator/prometheus/prometheus-host.yml
@@ -1,0 +1,39 @@
+global:
+  scrape_interval: 15s
+  scrape_timeout: 10s
+  evaluation_interval: 15s
+
+scrape_configs:
+  - job_name: prometheus
+    static_configs:
+      - targets: ["cluster_prometheus:9090"]
+        labels:
+          host_scope: cluster
+
+  - job_name: node-exporter
+    static_configs:
+      - targets: ["host.metrics.internal:9100"]
+        labels:
+          host_scope: cluster
+
+  - job_name: cadvisor
+    static_configs:
+      - targets: ["cluster_cadvisor:8080"]
+        labels:
+          host_scope: cluster
+    metric_relabel_configs:
+      - source_labels: [container_label_oakestra_logging_collector]
+        regex: cluster
+        action: keep
+      - source_labels: [container_label_com_docker_compose_service]
+        target_label: compose_service
+      - source_labels: [container_label_oakestra_cluster_id]
+        target_label: cluster_id
+      - regex: "container_label_.+"
+        action: labeldrop
+
+  - job_name: cluster-manager
+    static_configs:
+      - targets: ["host.docker.internal:10001"]
+        labels:
+          host_scope: cluster

--- a/cluster_orchestrator/prometheus/prometheus.yml
+++ b/cluster_orchestrator/prometheus/prometheus.yml
@@ -1,20 +1,39 @@
-# my global config
 global:
-  scrape_interval: 5s # Set the scrape interval to every 15 seconds. Default is every 1 minute.
-  evaluation_interval: 5s # Evaluate rules every 15 seconds. The default is every 1 minute.
-  # scrape_timeout is set to the global default (10s).
+  scrape_interval: 15s
+  scrape_timeout: 10s
+  evaluation_interval: 15s
 
-# Load rules once and periodically evaluate them according to the global 'evaluation_interval'.
-rule_files:
-#   - "first_rules.yml"
-#   - "second_rules.yml"
-
-# A scrape configuration containing exactly one endpoint to scrape:
-# Here it's Prometheus itself.
 scrape_configs:
-  # The job name is added as a label `job=<job_name>` to any timeseries scraped from this config.
-  - job_name: 'prometheus'
-    # metrics_path defaults to '/metrics'
-    # scheme defaults to 'http'.
+  - job_name: prometheus
     static_configs:
-    - targets: ['cluster_manager:10001']
+      - targets: ["cluster_prometheus:9090"]
+        labels:
+          host_scope: cluster
+
+  - job_name: node-exporter
+    static_configs:
+      - targets: ["host.metrics.internal:9100"]
+        labels:
+          host_scope: cluster
+
+  - job_name: cadvisor
+    static_configs:
+      - targets: ["cluster_cadvisor:8080"]
+        labels:
+          host_scope: cluster
+    metric_relabel_configs:
+      - source_labels: [container_label_oakestra_logging_collector]
+        regex: cluster
+        action: keep
+      - source_labels: [container_label_com_docker_compose_service]
+        target_label: compose_service
+      - source_labels: [container_label_oakestra_cluster_id]
+        target_label: cluster_id
+      - regex: "container_label_.+"
+        action: labeldrop
+
+  - job_name: cluster-manager
+    static_configs:
+      - targets: ["cluster_manager:10001"]
+        labels:
+          host_scope: cluster

--- a/root_orchestrator/config/README.md
+++ b/root_orchestrator/config/README.md
@@ -1,11 +1,12 @@
-# Alert & Logging Configuration
+# Observability Configuration
 
 
 ## Monitoring Services
-The proposed toolset for logs and alerting is based on:
+The observability stack is based on:
 - [Loki](https://grafana.com/docs/loki/latest/) is a highly-available, multi-tenant log aggregation system inspired by Prometheus. It focuses on logs instead of metrics, collecting logs via push instead of pull.
 - [Grafana Alloy](https://grafana.com/docs/alloy/latest/) is the collection agent. It discovers Docker containers, reads stdout/stderr, processes log lines, and forwards them to the local Loki instance.
-- [Grafana](https://grafana.com/docs/) is already in use for cluster metrics. Use Loki as data source for both logs and alerting.
+- [Prometheus](https://prometheus.io/docs/) stores host and container metrics collected from node_exporter and cAdvisor.
+- [Grafana](https://grafana.com/docs/) queries both local Loki logs and local Prometheus metrics.
 
 The high-level composition of the service is here sketched:
 
@@ -20,11 +21,17 @@ The high-level composition of the service is here sketched:
 At **root level**, each service is specified by:
 - `loki:3100`
 - `alloy`
+- `root_prometheus:9090`
+- `root_node_exporter:9100`
+- `root_cadvisor:8080`
 - `grafana:3000`
 
 At **cluster level**, each service is specified by:
 - `cluster_loki:3101`
 - `cluster_alloy`
+- `cluster_prometheus:9090`
+- `cluster_node_exporter:9100`
+- `cluster_cadvisor:8080`
 - `cluster_grafana:3001`
 
 Both two levels use different volumes for the configuration of the three services, respectively in [root_orchestrator/config/](../config/) and [cluster_orchestrator/config/](../../cluster_orchestrator/config/). Both `config` folders are structured as:
@@ -32,7 +39,7 @@ Both two levels use different volumes for the configuration of the three service
 ├── alerts
 │   ├── grafana-rules.yml         # Grafana-managed log alert rule
 │   └── grafana-contact-point.yml # Configurable webhook and email contact points
-├── grafana-datasources.yml # Loki datasource setup
+├── grafana-datasources.yml # Loki and Prometheus datasource setup
 ├── loki.yml                # Ingestion, storage config
 ├── config.alloy            # Alloy Docker discovery, processing, and Loki output
 └── dashboards
@@ -43,14 +50,31 @@ The configuration files can also be written at runtime but the volumes link allo
 
 
 > ⚠️ 
-> The *observability stack* can be ovverided to exclude the deployments of the three services at root/cluster deployment by:
+> The observability stack can be disabled with:
  ```bash
- docker-compose -f docker-compose.yml -f override-no-observe.yml up --build
+ docker compose -f docker-compose.yml -f override-no-observe.yml up --build
  ```
 > ⚠️
-> Alloy positions and Loki data use named volumes. Regular container recreation preserves them; `docker compose down -v` deliberately removes the stored state and log history.
+> Alloy positions, Loki data, and Prometheus metrics use named volumes. Regular container recreation preserves them; `docker compose down -v` deliberately removes their stored state.
 
 Alloy's diagnostic UI is available only from the orchestrator host at `http://127.0.0.1:12345`. It shows the component graph, health, and discovered targets. The loopback binding avoids exposing diagnostic and profiling endpoints to the deployment network.
+
+## Control-plane metrics
+
+Root Prometheus scrapes itself, `root_node_exporter`, and `root_cadvisor` every 15 seconds. It stores only this host's metrics: node_exporter provides host CPU, memory, filesystem, disk, and network counters, while cAdvisor provides matching per-container measurements. cAdvisor retains only Oakestra-labelled containers and exposes the low-cardinality `compose_service` and `cluster_id` labels used by later dashboards. Host-wide series use `host_scope="root"` because they describe a machine rather than an individual container.
+
+node_exporter shares the host network namespace so its network collector sees physical host interfaces rather than only a container `eth0`; it does not share the host PID namespace. Its listener is restricted to the private internal metrics-network gateway, and the process has read-only host mounts, no Linux capabilities, and `no-new-privileges`.
+
+Prometheus keeps at most seven days or 1 GB, whichever limit is reached first. Prometheus and node_exporter have no published ports in the normal bridge deployment; Grafana reaches Prometheus over Docker networking through the provisioned `Prometheus` datasource. cAdvisor's diagnostic UI and raw metrics are available only from the host at `http://127.0.0.1:8081` and `http://127.0.0.1:8081/metrics`. The host-network override additionally exposes Prometheus only on `127.0.0.1:10010` so host-networked Grafana can still query it.
+
+The metrics stack supports rootful Linux Docker Engine 25 or newer on AMD64 and ARM64. Set `DOCKER_ROOT_DIR` when Docker stores data outside `/var/lib/docker`. cAdvisor receives read-only host mounts and a read-only Docker socket, but Docker socket access remains security-sensitive, so its diagnostic endpoint is bound to loopback and must not be rebound to a LAN or Tailscale address. Unsupported hosts must use `override-no-observe.yml`.
+
+Check the scrape targets without exposing Prometheus:
+
+```bash
+docker exec root_prometheus promtool query instant http://127.0.0.1:9090 up
+docker exec root_prometheus promtool query instant http://127.0.0.1:9090 prometheus_tsdb_head_series
+```
 
 ## Provisioned logs dashboard
 

--- a/root_orchestrator/config/alerts/grafana-rules.yml
+++ b/root_orchestrator/config/alerts/grafana-rules.yml
@@ -25,7 +25,7 @@ groups:
                 (
                   sum by (cluster_id, compose_service) (
                     count_over_time(
-                      {cluster_id=~".+", compose_service=~".+", compose_service!~"^(grafana|cluster_grafana|loki|cluster_loki|alloy|cluster_alloy|prometheus)$", level=~"error|critical"}
+                      {cluster_id=~".+", compose_service=~".+", compose_service!~"^(grafana|cluster_grafana|loki|cluster_loki|alloy|cluster_alloy|prometheus|node_exporter|cadvisor)$", level=~"error|critical"}
                       | json
                       | __error__ = ""
                       | schema_version = 1
@@ -37,7 +37,7 @@ groups:
                 (
                   sum by (cluster_id, compose_service) (
                     count_over_time(
-                      {cluster_id=~".+", compose_service=~".+", compose_service!~"^(grafana|cluster_grafana|loki|cluster_loki|alloy|cluster_alloy|prometheus)$"}
+                      {cluster_id=~".+", compose_service=~".+", compose_service!~"^(grafana|cluster_grafana|loki|cluster_loki|alloy|cluster_alloy|prometheus|node_exporter|cadvisor)$"}
                       !~ `"schema_version"\s*:\s*1\s*[,}]`
                       |~ `(?i:\b(ERROR|FATAL|CRITICAL|EXCEPTION)\b|Traceback \(most recent call last\):|panic:|fatal error:|runtime error:|goroutine [0-9]+ \[|File ".*", line [0-9]+|\.go:[0-9]+ \+0x|\[[EF][0-9])`
                       [2m]

--- a/root_orchestrator/config/config.alloy
+++ b/root_orchestrator/config/config.alloy
@@ -190,11 +190,11 @@ loki.process "oakestra" {
 		}
 	}
 
-	// Grafana, Loki, Alloy, and Prometheus emit logfmt. Parsing only these known
+	// Grafana, Loki, Alloy, Prometheus, and node_exporter emit logfmt. Parsing only these known
 	// emitters reads the real top-level level field instead of matching text
 	// embedded later in a message or query.
 	stage.match {
-		selector = `{compose_service=~"alloy|cluster_alloy|grafana|cluster_grafana|loki|cluster_loki|prometheus"}`
+		selector = `{compose_service=~"alloy|cluster_alloy|grafana|cluster_grafana|loki|cluster_loki|prometheus|node_exporter"}`
 
 		stage.logfmt {
 			mapping = {

--- a/root_orchestrator/config/dashboards/log-statistics-dashboard.json
+++ b/root_orchestrator/config/dashboards/log-statistics-dashboard.json
@@ -1120,7 +1120,7 @@
           {
             "selected": false,
             "text": "Observability",
-            "value": "^(alloy|grafana|loki|cluster_alloy|cluster_grafana|cluster_loki|prometheus)$"
+            "value": "^(alloy|grafana|loki|cluster_alloy|cluster_grafana|cluster_loki|prometheus|node_exporter|cadvisor)$"
           },
           {
             "selected": false,
@@ -1133,7 +1133,7 @@
             "value": ".+"
           }
         ],
-        "query": "Oakestra services : ^(system_manager|root_scheduler|root_resource_abstractor|resource_abstractor|root_service_manager|jwt_generator|dashboard|marketplace_manager|root_addons_dashboard|root_addons_manager|root_addons_monitor|addons_dashboard|addons_manager|addons_monitor|cluster_manager|cluster_scheduler|cluster_resource_abstractor|cluster_service_manager|cluster_addons_dashboard|cluster_addons_manager|cluster_addons_monitor|mqtt)$, Observability : ^(alloy|grafana|loki|cluster_alloy|cluster_grafana|cluster_loki|prometheus)$, Data stores : ^(mongo_root|mongo_rootnet|root_redis|redis|mongo_cluster|mongo_clusternet|cluster_redis)$, All containers : .+",
+        "query": "Oakestra services : ^(system_manager|root_scheduler|root_resource_abstractor|resource_abstractor|root_service_manager|jwt_generator|dashboard|marketplace_manager|root_addons_dashboard|root_addons_manager|root_addons_monitor|addons_dashboard|addons_manager|addons_monitor|cluster_manager|cluster_scheduler|cluster_resource_abstractor|cluster_service_manager|cluster_addons_dashboard|cluster_addons_manager|cluster_addons_monitor|mqtt)$, Observability : ^(alloy|grafana|loki|cluster_alloy|cluster_grafana|cluster_loki|prometheus|node_exporter|cadvisor)$, Data stores : ^(mongo_root|mongo_rootnet|root_redis|redis|mongo_cluster|mongo_clusternet|cluster_redis)$, All containers : .+",
         "queryValue": "",
         "skipUrlSync": false,
         "type": "custom"

--- a/root_orchestrator/config/dashboards/logs-dashboard.json
+++ b/root_orchestrator/config/dashboards/logs-dashboard.json
@@ -191,7 +191,7 @@
           {
             "selected": false,
             "text": "Observability",
-            "value": "^(alloy|grafana|loki|cluster_alloy|cluster_grafana|cluster_loki|prometheus)$"
+            "value": "^(alloy|grafana|loki|cluster_alloy|cluster_grafana|cluster_loki|prometheus|node_exporter|cadvisor)$"
           },
           {
             "selected": false,
@@ -204,7 +204,7 @@
             "value": ".+"
           }
         ],
-        "query": "Oakestra services : ^(system_manager|root_scheduler|root_resource_abstractor|resource_abstractor|root_service_manager|jwt_generator|dashboard|marketplace_manager|root_addons_dashboard|root_addons_manager|root_addons_monitor|addons_dashboard|addons_manager|addons_monitor|cluster_manager|cluster_scheduler|cluster_resource_abstractor|cluster_service_manager|cluster_addons_dashboard|cluster_addons_manager|cluster_addons_monitor|mqtt)$, Observability : ^(alloy|grafana|loki|cluster_alloy|cluster_grafana|cluster_loki|prometheus)$, Data stores : ^(mongo_root|mongo_rootnet|root_redis|redis|mongo_cluster|mongo_clusternet|cluster_redis)$, All containers : .+",
+        "query": "Oakestra services : ^(system_manager|root_scheduler|root_resource_abstractor|resource_abstractor|root_service_manager|jwt_generator|dashboard|marketplace_manager|root_addons_dashboard|root_addons_manager|root_addons_monitor|addons_dashboard|addons_manager|addons_monitor|cluster_manager|cluster_scheduler|cluster_resource_abstractor|cluster_service_manager|cluster_addons_dashboard|cluster_addons_manager|cluster_addons_monitor|mqtt)$, Observability : ^(alloy|grafana|loki|cluster_alloy|cluster_grafana|cluster_loki|prometheus|node_exporter|cadvisor)$, Data stores : ^(mongo_root|mongo_rootnet|root_redis|redis|mongo_cluster|mongo_clusternet|cluster_redis)$, All containers : .+",
         "queryValue": "",
         "skipUrlSync": false,
         "type": "custom"

--- a/root_orchestrator/config/grafana-datasources.yml
+++ b/root_orchestrator/config/grafana-datasources.yml
@@ -31,3 +31,14 @@ datasources:
           matcherRegex: '\b([a-fA-F0-9]{24})\b'
           url: '/d/oakestra-logs/oakestra-orchestrator-logs?orgId=1&$${__url_time_range}&var-cluster_id=root&var-source_scope=.%2B&var-compose_service=root_service_manager&var-level_filter=.%2A&var-search=$${__value.raw}&var-logql_pipeline='
           urlDisplayLabel: "Search this ID in Root Service Manager"
+
+  - name: Prometheus
+    type: prometheus
+    uid: Prometheus
+    access: proxy
+    url: $PROMETHEUS_URL
+    editable: true
+    isDefault: false
+    jsonData:
+      httpMethod: POST
+      timeInterval: 15s

--- a/root_orchestrator/docker-compose.yml
+++ b/root_orchestrator/docker-compose.yml
@@ -108,6 +108,141 @@ services:
       - "6379:6379"
     command: redis-server --requirepass rootRedis
 
+  prometheus:
+    image: prom/prometheus:v3.13.2-distroless
+    container_name: root_prometheus
+    hostname: root_prometheus
+    labels: *root-log-labels
+    expose:
+      - "9090"
+    volumes:
+      - ./prometheus/prometheus.yml:/etc/prometheus/prometheus.yml:ro
+      - root_prometheus_data:/prometheus
+    command:
+      - --config.file=/etc/prometheus/prometheus.yml
+      - --storage.tsdb.path=/prometheus
+      - --storage.tsdb.retention.time=7d
+      - --storage.tsdb.retention.size=1GB
+    depends_on:
+      - node_exporter
+      - cadvisor
+    extra_hosts:
+      - host.metrics.internal=${ROOT_METRICS_GATEWAY:-172.30.250.1}
+    networks:
+      - default
+      - metrics
+    read_only: true
+    tmpfs:
+      - /tmp
+    cap_drop:
+      - ALL
+    security_opt:
+      - no-new-privileges:true
+    restart: unless-stopped
+    logging: *default-logging
+
+  node_exporter:
+    image: quay.io/prometheus/node-exporter:v1.12.1
+    container_name: root_node_exporter
+    hostname: root_node_exporter
+    labels: *root-log-labels
+    network_mode: host
+    command:
+      - --path.procfs=/host/proc
+      - --path.sysfs=/host/sys
+      - --path.rootfs=/host
+      - --collector.filesystem.mount-points-exclude=^/(dev|proc|sys|var/lib/docker/.+|var/lib/containers/storage/.+)($$|/)
+      - --web.listen-address=${ROOT_METRICS_GATEWAY:-172.30.250.1}:9100
+      - --web.max-requests=5
+    volumes:
+      - type: bind
+        source: /proc
+        target: /host/proc
+        read_only: true
+        bind:
+          create_host_path: false
+      - type: bind
+        source: /sys
+        target: /host/sys
+        read_only: true
+        bind:
+          create_host_path: false
+      - type: bind
+        source: /
+        target: /host
+        read_only: true
+        bind:
+          propagation: rslave
+    read_only: true
+    cap_drop:
+      - ALL
+    security_opt:
+      - no-new-privileges:true
+    restart: unless-stopped
+    logging: *default-logging
+
+  cadvisor:
+    image: ghcr.io/google/cadvisor:v0.60.5
+    container_name: root_cadvisor
+    hostname: root_cadvisor
+    labels: *root-log-labels
+    ports:
+      - "127.0.0.1:8081:8080"
+    command:
+      - --docker_only=true
+      - --store_container_labels=false
+      - --whitelisted_container_labels=com.docker.compose.service,oakestra.cluster.id,oakestra.logging.collector
+      - --enable_metrics=cpu,disk,diskIO,memory,network
+      - --housekeeping_interval=10s
+      - --max_housekeeping_interval=15s
+      - --storage_duration=1m
+    volumes:
+      - type: bind
+        source: /
+        target: /rootfs
+        read_only: true
+        bind:
+          propagation: rslave
+      - type: bind
+        source: /sys
+        target: /sys
+        read_only: true
+        bind:
+          create_host_path: false
+      - type: bind
+        source: /var/run/docker.sock
+        target: /var/run/docker.sock
+        read_only: true
+        bind:
+          create_host_path: false
+      - type: bind
+        source: ${CONTAINERD_SOCKET:-/run/containerd/containerd.sock}
+        target: ${CONTAINERD_SOCKET:-/run/containerd/containerd.sock}
+        read_only: true
+        bind:
+          create_host_path: false
+      - type: bind
+        source: ${DOCKER_ROOT_DIR:-/var/lib/docker}
+        target: ${DOCKER_ROOT_DIR:-/var/lib/docker}
+        read_only: true
+        bind:
+          create_host_path: false
+      - type: bind
+        source: /dev/disk
+        target: /dev/disk
+        read_only: true
+        bind:
+          create_host_path: false
+    read_only: true
+    tmpfs:
+      - /tmp
+    cap_drop:
+      - ALL
+    security_opt:
+      - no-new-privileges:true
+    restart: unless-stopped
+    logging: *default-logging
+
   # Observability Stack
   grafana:
     image: grafana/grafana
@@ -117,6 +252,7 @@ services:
     ports:
       - 3000:3000
     environment:
+      - PROMETHEUS_URL=http://root_prometheus:9090
       - OAKESTRA_ALERT_CONTACT_POINT=${OAKESTRA_ALERT_CONTACT_POINT:-Oakestra Alert Webhook}
       - OAKESTRA_ALERT_WEBHOOK_URL=${OAKESTRA_ALERT_WEBHOOK_URL:-http://127.0.0.1:65535/oakestra-alerts}
       - OAKESTRA_ALERT_EMAIL_TO=${OAKESTRA_ALERT_EMAIL_TO:-alerts@example.invalid}
@@ -346,7 +482,15 @@ volumes:
     driver: local
   loki_data:
     driver: local
+  root_prometheus_data:
+    driver: local
 
 networks:
   default:
     name: oakestra
+  metrics:
+    internal: true
+    ipam:
+      config:
+        - subnet: ${ROOT_METRICS_SUBNET:-172.30.250.0/24}
+          gateway: ${ROOT_METRICS_GATEWAY:-172.30.250.1}

--- a/root_orchestrator/override-images-only.yml
+++ b/root_orchestrator/override-images-only.yml
@@ -19,6 +19,18 @@ services:
     image: redis
     pull_policy: always
 
+  prometheus:
+    image: prom/prometheus:v3.13.2-distroless
+    pull_policy: always
+
+  node_exporter:
+    image: quay.io/prometheus/node-exporter:v1.12.1
+    pull_policy: always
+
+  cadvisor:
+    image: ghcr.io/google/cadvisor:v0.60.5
+    pull_policy: always
+
   grafana:
     image: grafana/grafana
     pull_policy: always

--- a/root_orchestrator/override-ipv6-enabled.yml
+++ b/root_orchestrator/override-ipv6-enabled.yml
@@ -1,5 +1,3 @@
-version: "3.3"
-
 services:
   system_manager:
     networks:
@@ -27,7 +25,7 @@ services:
         ipv4_address: 192.168.128.3
         ipv6_address: 2001:db8:a::3
 
-  redis:
+  root_redis:
     networks:
       root_net:
         ipv4_address: 192.168.128.8
@@ -38,6 +36,30 @@ services:
       root_net:
         ipv4_address: 192.168.128.9
         ipv6_address: 2001:db8:a::9
+
+  prometheus:
+    networks:
+      root_net:
+        ipv4_address: 192.168.128.11
+        ipv6_address: 2001:db8:a::11
+
+  cadvisor:
+    networks:
+      root_net:
+        ipv4_address: 192.168.128.12
+        ipv6_address: 2001:db8:a::12
+
+  loki:
+    networks:
+      root_net:
+        ipv4_address: 192.168.128.13
+        ipv6_address: 2001:db8:a::13
+
+  alloy:
+    networks:
+      root_net:
+        ipv4_address: 192.168.128.14
+        ipv6_address: 2001:db8:a::14
 
   dashboard:
     networks:
@@ -51,7 +73,7 @@ services:
         ipv4_address: 192.168.128.7
         ipv6_address: 2001:db8:a::7
 
-  resource_abstractor:
+  root_resource_abstractor:
     networks:
       root_net:
         ipv4_address: 192.168.128.10

--- a/root_orchestrator/override-network-host.yml
+++ b/root_orchestrator/override-network-host.yml
@@ -41,6 +41,12 @@ services:
   # Observability Stack
   grafana:
     network_mode: host
+    environment:
+      - PROMETHEUS_URL=http://127.0.0.1:10010
+
+  prometheus:
+    ports:
+      - 127.0.0.1:10010:9090
 
   loki:
     network_mode: host

--- a/root_orchestrator/override-no-observe.yml
+++ b/root_orchestrator/override-no-observe.yml
@@ -13,3 +13,15 @@ services:
     deploy:
       mode: replicated
       replicas: 0
+  prometheus:
+    deploy:
+      mode: replicated
+      replicas: 0
+  node_exporter:
+    deploy:
+      mode: replicated
+      replicas: 0
+  cadvisor:
+    deploy:
+      mode: replicated
+      replicas: 0

--- a/root_orchestrator/prometheus/prometheus.yml
+++ b/root_orchestrator/prometheus/prometheus.yml
@@ -6,24 +6,24 @@ global:
 scrape_configs:
   - job_name: prometheus
     static_configs:
-      - targets: ["prometheus:9090"]
+      - targets: ["root_prometheus:9090"]
         labels:
-          host_scope: one-doc
+          host_scope: root
 
   - job_name: node-exporter
     static_configs:
       - targets: ["host.metrics.internal:9100"]
         labels:
-          host_scope: one-doc
+          host_scope: root
 
   - job_name: cadvisor
     static_configs:
-      - targets: ["cadvisor:8080"]
+      - targets: ["root_cadvisor:8080"]
         labels:
-          host_scope: one-doc
+          host_scope: root
     metric_relabel_configs:
       - source_labels: [container_label_oakestra_logging_collector]
-        regex: one-doc
+        regex: root
         action: keep
       - source_labels: [container_label_com_docker_compose_service]
         target_label: compose_service
@@ -31,9 +31,3 @@ scrape_configs:
         target_label: cluster_id
       - regex: "container_label_.+"
         action: labeldrop
-
-  - job_name: cluster-manager
-    static_configs:
-      - targets: ["cluster_manager:10001"]
-        labels:
-          host_scope: one-doc

--- a/run-a-cluster/1-DOC.yaml
+++ b/run-a-cluster/1-DOC.yaml
@@ -377,17 +377,143 @@ services:
 
 
   prometheus:
-    image: prom/prometheus
+    image: prom/prometheus:v3.13.2-distroless
     pull_policy: always
     container_name: prometheus
     hostname: prometheus
-    labels: *cluster-log-labels
+    labels: *shared-log-labels
+    expose:
+      - "9090"
     volumes:
-      - ./prometheus/:/etc/prometheus/
+      - ./prometheus/prometheus.yml:/etc/prometheus/prometheus.yml:ro
+      - prometheus_data:/prometheus
     command:
-      - '--config.file=/etc/prometheus/prometheus.yml'
+      - --config.file=/etc/prometheus/prometheus.yml
+      - --storage.tsdb.path=/prometheus
+      - --storage.tsdb.retention.time=7d
+      - --storage.tsdb.retention.size=1GB
     depends_on:
       - cluster_manager
+      - node_exporter
+      - cadvisor
+    extra_hosts:
+      - host.metrics.internal=${ONE_DOC_METRICS_GATEWAY:-172.30.252.1}
+    networks:
+      - default
+      - metrics
+    read_only: true
+    tmpfs:
+      - /tmp
+    cap_drop:
+      - ALL
+    security_opt:
+      - no-new-privileges:true
+    restart: unless-stopped
+    logging: *default-logging
+
+  node_exporter:
+    image: quay.io/prometheus/node-exporter:v1.12.1
+    pull_policy: always
+    container_name: node_exporter
+    hostname: node_exporter
+    labels: *shared-log-labels
+    network_mode: host
+    command:
+      - --path.procfs=/host/proc
+      - --path.sysfs=/host/sys
+      - --path.rootfs=/host
+      - --collector.filesystem.mount-points-exclude=^/(dev|proc|sys|var/lib/docker/.+|var/lib/containers/storage/.+)($$|/)
+      - --web.listen-address=${ONE_DOC_METRICS_GATEWAY:-172.30.252.1}:9100
+      - --web.max-requests=5
+    volumes:
+      - type: bind
+        source: /proc
+        target: /host/proc
+        read_only: true
+        bind:
+          create_host_path: false
+      - type: bind
+        source: /sys
+        target: /host/sys
+        read_only: true
+        bind:
+          create_host_path: false
+      - type: bind
+        source: /
+        target: /host
+        read_only: true
+        bind:
+          propagation: rslave
+    read_only: true
+    cap_drop:
+      - ALL
+    security_opt:
+      - no-new-privileges:true
+    restart: unless-stopped
+    logging: *default-logging
+
+  cadvisor:
+    image: ghcr.io/google/cadvisor:v0.60.5
+    pull_policy: always
+    container_name: cadvisor
+    hostname: cadvisor
+    labels: *shared-log-labels
+    ports:
+      - "127.0.0.1:8081:8080"
+    command:
+      - --docker_only=true
+      - --store_container_labels=false
+      - --whitelisted_container_labels=com.docker.compose.service,oakestra.cluster.id,oakestra.logging.collector
+      - --enable_metrics=cpu,disk,diskIO,memory,network
+      - --housekeeping_interval=10s
+      - --max_housekeeping_interval=15s
+      - --storage_duration=1m
+    volumes:
+      - type: bind
+        source: /
+        target: /rootfs
+        read_only: true
+        bind:
+          propagation: rslave
+      - type: bind
+        source: /sys
+        target: /sys
+        read_only: true
+        bind:
+          create_host_path: false
+      - type: bind
+        source: /var/run/docker.sock
+        target: /var/run/docker.sock
+        read_only: true
+        bind:
+          create_host_path: false
+      - type: bind
+        source: ${CONTAINERD_SOCKET:-/run/containerd/containerd.sock}
+        target: ${CONTAINERD_SOCKET:-/run/containerd/containerd.sock}
+        read_only: true
+        bind:
+          create_host_path: false
+      - type: bind
+        source: ${DOCKER_ROOT_DIR:-/var/lib/docker}
+        target: ${DOCKER_ROOT_DIR:-/var/lib/docker}
+        read_only: true
+        bind:
+          create_host_path: false
+      - type: bind
+        source: /dev/disk
+        target: /dev/disk
+        read_only: true
+        bind:
+          create_host_path: false
+    read_only: true
+    tmpfs:
+      - /tmp
+    cap_drop:
+      - ALL
+    security_opt:
+      - no-new-privileges:true
+    restart: unless-stopped
+    logging: *default-logging
   
 
   # Shared 1-DOC observability stack (Alloy, Loki, Grafana)
@@ -400,6 +526,7 @@ services:
     ports:
       - 3000:3000
     environment:
+      - PROMETHEUS_URL=http://prometheus:9090
       - OAKESTRA_ALERT_CONTACT_POINT=${OAKESTRA_ALERT_CONTACT_POINT:-Oakestra Alert Webhook}
       - OAKESTRA_ALERT_WEBHOOK_URL=${OAKESTRA_ALERT_WEBHOOK_URL:-http://127.0.0.1:65535/oakestra-alerts}
       - OAKESTRA_ALERT_EMAIL_TO=${OAKESTRA_ALERT_EMAIL_TO:-alerts@example.invalid}
@@ -547,10 +674,18 @@ volumes:
     driver: local
   loki_data:
     driver: local
+  prometheus_data:
+    driver: local
   
 
 networks:
   default:
     name: oakestra
+  metrics:
+    internal: true
+    ipam:
+      config:
+        - subnet: ${ONE_DOC_METRICS_SUBNET:-172.30.252.0/24}
+          gateway: ${ONE_DOC_METRICS_GATEWAY:-172.30.252.1}
   ip6net:
     enable_ipv6: true

--- a/run-a-cluster/config/README.md
+++ b/run-a-cluster/config/README.md
@@ -1,11 +1,12 @@
-# Alert & Logging Configuration
+# Observability Configuration
 
 
 ## Monitoring Services
-The proposed toolset for logs and alerting is based on:
+The observability stack is based on:
 - [Loki](https://grafana.com/docs/loki/latest/) is a highly-available, multi-tenant log aggregation system inspired by Prometheus. It focuses on logs instead of metrics, collecting logs via push instead of pull.
 - [Grafana Alloy](https://grafana.com/docs/alloy/latest/) is the collection agent. It discovers Docker containers, reads stdout/stderr, processes log lines, and forwards them to the local Loki instance.
-- [Grafana](https://grafana.com/docs/) is already in use for cluster metrics. Use Loki as data source for both logs and alerting.
+- [Prometheus](https://prometheus.io/docs/) stores host and container metrics collected from node_exporter and cAdvisor.
+- [Grafana](https://grafana.com/docs/) queries both local Loki logs and local Prometheus metrics.
 
 The high-level composition of the services is here sketched:
 
@@ -20,6 +21,9 @@ The high-level composition of the services is here sketched:
 At **root level**, each service is specified by:
 - `loki:3100`
 - `alloy`
+- `prometheus:9090`
+- `node_exporter:9100`
+- `cadvisor:8080`
 - `grafana:3000`
 
 At **cluster level**, each service is specified by:
@@ -32,7 +36,7 @@ Both two levels use different volumes for the configuration of the three service
 ├── alerts
 │   ├── grafana-rules.yml         # Grafana-managed log alert rule
 │   └── grafana-contact-point.yml # Configurable webhook and email contact points
-├── grafana-datasources.yml # Loki datasource setup
+├── grafana-datasources.yml # Loki and Prometheus datasource setup
 ├── loki.yml                # Ingestion, storage config
 ├── config.alloy            # Alloy Docker discovery, processing, and Loki output
 └── dashboards
@@ -43,14 +47,29 @@ The configuration files can also be written at runtime but the volumes link allo
 
 
 > ⚠️ 
-> The *observability stack* can be ovverided to exclude the deployments of the three services at root/cluster deployment by:
+> The observability stack can be disabled with:
  ```bash
- docker-compose -f docker-compose.yml -f override-no-observe.yml up --build
+ docker compose -f 1-DOC.yaml -f override-no-observe.yml up -d
  ```
 > ⚠️
-> Alloy positions and Loki data use named volumes. Regular container recreation preserves them; `docker compose down -v` deliberately removes the stored state and log history.
+> Alloy positions, Loki data, and Prometheus metrics use named volumes. Regular container recreation preserves them; `docker compose down -v` deliberately removes their stored state.
 
 Alloy's diagnostic UI is available only from the orchestrator host at `http://127.0.0.1:12345`. It shows the component graph, health, and discovered targets. The loopback binding avoids exposing diagnostic and profiling endpoints to the deployment network.
+
+## Control-plane metrics
+
+A 1-DOC deployment runs one Prometheus, one node_exporter, and one cAdvisor because Root and Cluster share one physical host and Docker daemon. Prometheus scrapes those targets, itself, and Cluster Manager every 15 seconds. Host metrics use `host_scope="one-doc"`; cAdvisor container metrics retain the existing `cluster_id` values (`root`, the configured Cluster name, or `one-doc`) and `compose_service`, so the two logical orchestration planes remain distinguishable without collecting the machine twice.
+
+node_exporter shares the host network namespace so its network collector sees physical host interfaces rather than only a container `eth0`; it does not share the host PID namespace. Its listener is restricted to the private internal metrics-network gateway, and the process has read-only host mounts, no Linux capabilities, and `no-new-privileges`.
+
+The direct [`root-orchestrator.yml`](../root-orchestrator.yml) deployment uses the separate `prometheus-root.yml` configuration and the same Root-local ownership model as the source Compose deployment.
+
+Prometheus keeps at most seven days or 1 GB. Grafana accesses it through the provisioned `Prometheus` datasource, while node_exporter remains internal. cAdvisor's diagnostic UI and raw metrics are available only from the host at `http://127.0.0.1:8081` and `http://127.0.0.1:8081/metrics`. The metrics stack requires rootful Linux Docker Engine 25 or newer on AMD64 or ARM64. Set `DOCKER_ROOT_DIR` for a custom Docker data directory and use `override-no-observe.yml` on unsupported hosts. cAdvisor's read-only Docker socket and host mounts still expose sensitive host metadata, so its port must remain loopback-only.
+
+```bash
+docker exec prometheus promtool query instant http://127.0.0.1:9090 up
+docker exec prometheus promtool query instant http://127.0.0.1:9090 prometheus_tsdb_head_series
+```
 
 ## Provisioned logs dashboard
 

--- a/run-a-cluster/config/alerts/grafana-rules.yml
+++ b/run-a-cluster/config/alerts/grafana-rules.yml
@@ -25,7 +25,7 @@ groups:
                 (
                   sum by (cluster_id, compose_service) (
                     count_over_time(
-                      {cluster_id=~".+", compose_service=~".+", compose_service!~"^(grafana|cluster_grafana|loki|cluster_loki|alloy|cluster_alloy|prometheus)$", level=~"error|critical"}
+                      {cluster_id=~".+", compose_service=~".+", compose_service!~"^(grafana|cluster_grafana|loki|cluster_loki|alloy|cluster_alloy|prometheus|node_exporter|cadvisor)$", level=~"error|critical"}
                       | json
                       | __error__ = ""
                       | schema_version = 1
@@ -37,7 +37,7 @@ groups:
                 (
                   sum by (cluster_id, compose_service) (
                     count_over_time(
-                      {cluster_id=~".+", compose_service=~".+", compose_service!~"^(grafana|cluster_grafana|loki|cluster_loki|alloy|cluster_alloy|prometheus)$"}
+                      {cluster_id=~".+", compose_service=~".+", compose_service!~"^(grafana|cluster_grafana|loki|cluster_loki|alloy|cluster_alloy|prometheus|node_exporter|cadvisor)$"}
                       !~ `"schema_version"\s*:\s*1\s*[,}]`
                       |~ `(?i:\b(ERROR|FATAL|CRITICAL|EXCEPTION)\b|Traceback \(most recent call last\):|panic:|fatal error:|runtime error:|goroutine [0-9]+ \[|File ".*", line [0-9]+|\.go:[0-9]+ \+0x|\[[EF][0-9])`
                       [2m]

--- a/run-a-cluster/config/config.alloy
+++ b/run-a-cluster/config/config.alloy
@@ -189,11 +189,11 @@ loki.process "oakestra" {
 		}
 	}
 
-	// Grafana, Loki, Alloy, and Prometheus emit logfmt. Parsing only these known
+	// Grafana, Loki, Alloy, Prometheus, and node_exporter emit logfmt. Parsing only these known
 	// emitters reads the real top-level level field instead of matching text
 	// embedded later in a message or query.
 	stage.match {
-		selector = `{compose_service=~"alloy|cluster_alloy|grafana|cluster_grafana|loki|cluster_loki|prometheus"}`
+		selector = `{compose_service=~"alloy|cluster_alloy|grafana|cluster_grafana|loki|cluster_loki|prometheus|node_exporter"}`
 
 		stage.logfmt {
 			mapping = {

--- a/run-a-cluster/config/dashboards/log-statistics-dashboard.json
+++ b/run-a-cluster/config/dashboards/log-statistics-dashboard.json
@@ -1120,7 +1120,7 @@
           {
             "selected": false,
             "text": "Observability",
-            "value": "^(alloy|grafana|loki|cluster_alloy|cluster_grafana|cluster_loki|prometheus)$"
+            "value": "^(alloy|grafana|loki|cluster_alloy|cluster_grafana|cluster_loki|prometheus|node_exporter|cadvisor)$"
           },
           {
             "selected": false,
@@ -1133,7 +1133,7 @@
             "value": ".+"
           }
         ],
-        "query": "Oakestra services : ^(system_manager|root_scheduler|root_resource_abstractor|resource_abstractor|root_service_manager|jwt_generator|dashboard|marketplace_manager|root_addons_dashboard|root_addons_manager|root_addons_monitor|addons_dashboard|addons_manager|addons_monitor|cluster_manager|cluster_scheduler|cluster_resource_abstractor|cluster_service_manager|cluster_addons_dashboard|cluster_addons_manager|cluster_addons_monitor|mqtt)$, Observability : ^(alloy|grafana|loki|cluster_alloy|cluster_grafana|cluster_loki|prometheus)$, Data stores : ^(mongo_root|mongo_rootnet|root_redis|redis|mongo_cluster|mongo_clusternet|cluster_redis)$, All containers : .+",
+        "query": "Oakestra services : ^(system_manager|root_scheduler|root_resource_abstractor|resource_abstractor|root_service_manager|jwt_generator|dashboard|marketplace_manager|root_addons_dashboard|root_addons_manager|root_addons_monitor|addons_dashboard|addons_manager|addons_monitor|cluster_manager|cluster_scheduler|cluster_resource_abstractor|cluster_service_manager|cluster_addons_dashboard|cluster_addons_manager|cluster_addons_monitor|mqtt)$, Observability : ^(alloy|grafana|loki|cluster_alloy|cluster_grafana|cluster_loki|prometheus|node_exporter|cadvisor)$, Data stores : ^(mongo_root|mongo_rootnet|root_redis|redis|mongo_cluster|mongo_clusternet|cluster_redis)$, All containers : .+",
         "queryValue": "",
         "skipUrlSync": false,
         "type": "custom"

--- a/run-a-cluster/config/dashboards/logs-dashboard.json
+++ b/run-a-cluster/config/dashboards/logs-dashboard.json
@@ -191,7 +191,7 @@
           {
             "selected": false,
             "text": "Observability",
-            "value": "^(alloy|grafana|loki|cluster_alloy|cluster_grafana|cluster_loki|prometheus)$"
+            "value": "^(alloy|grafana|loki|cluster_alloy|cluster_grafana|cluster_loki|prometheus|node_exporter|cadvisor)$"
           },
           {
             "selected": false,
@@ -204,7 +204,7 @@
             "value": ".+"
           }
         ],
-        "query": "Oakestra services : ^(system_manager|root_scheduler|root_resource_abstractor|resource_abstractor|root_service_manager|jwt_generator|dashboard|marketplace_manager|root_addons_dashboard|root_addons_manager|root_addons_monitor|addons_dashboard|addons_manager|addons_monitor|cluster_manager|cluster_scheduler|cluster_resource_abstractor|cluster_service_manager|cluster_addons_dashboard|cluster_addons_manager|cluster_addons_monitor|mqtt)$, Observability : ^(alloy|grafana|loki|cluster_alloy|cluster_grafana|cluster_loki|prometheus)$, Data stores : ^(mongo_root|mongo_rootnet|root_redis|redis|mongo_cluster|mongo_clusternet|cluster_redis)$, All containers : .+",
+        "query": "Oakestra services : ^(system_manager|root_scheduler|root_resource_abstractor|resource_abstractor|root_service_manager|jwt_generator|dashboard|marketplace_manager|root_addons_dashboard|root_addons_manager|root_addons_monitor|addons_dashboard|addons_manager|addons_monitor|cluster_manager|cluster_scheduler|cluster_resource_abstractor|cluster_service_manager|cluster_addons_dashboard|cluster_addons_manager|cluster_addons_monitor|mqtt)$, Observability : ^(alloy|grafana|loki|cluster_alloy|cluster_grafana|cluster_loki|prometheus|node_exporter|cadvisor)$, Data stores : ^(mongo_root|mongo_rootnet|root_redis|redis|mongo_cluster|mongo_clusternet|cluster_redis)$, All containers : .+",
         "queryValue": "",
         "skipUrlSync": false,
         "type": "custom"

--- a/run-a-cluster/config/grafana-datasources.yml
+++ b/run-a-cluster/config/grafana-datasources.yml
@@ -47,3 +47,14 @@ datasources:
           matcherRegex: '\b([a-fA-F0-9]{24})\b'
           url: '/d/oakestra-logs/oakestra-orchestrator-logs?orgId=1&$${__url_time_range}&var-cluster_id=All&var-source_scope=.%2B&var-compose_service=cluster_service_manager&var-level_filter=.%2A&var-search=$${__value.raw}&var-logql_pipeline='
           urlDisplayLabel: "Search this ID in Cluster Service Manager"
+
+  - name: Prometheus
+    type: prometheus
+    uid: Prometheus
+    access: proxy
+    url: $PROMETHEUS_URL
+    editable: true
+    isDefault: false
+    jsonData:
+      httpMethod: POST
+      timeInterval: 15s

--- a/run-a-cluster/override-no-observe.yml
+++ b/run-a-cluster/override-no-observe.yml
@@ -1,15 +1,13 @@
 services:
-
-  # Remove observability services for cluster components
-  cluster_alloy:
+  alloy:
     deploy:
       mode: replicated
       replicas: 0
-  cluster_loki:
+  loki:
     deploy:
       mode: replicated
       replicas: 0
-  cluster_grafana:
+  grafana:
     deploy:
       mode: replicated
       replicas: 0

--- a/run-a-cluster/prometheus/prometheus-root.yml
+++ b/run-a-cluster/prometheus/prometheus-root.yml
@@ -1,0 +1,33 @@
+global:
+  scrape_interval: 15s
+  scrape_timeout: 10s
+  evaluation_interval: 15s
+
+scrape_configs:
+  - job_name: prometheus
+    static_configs:
+      - targets: ["root_prometheus:9090"]
+        labels:
+          host_scope: root
+
+  - job_name: node-exporter
+    static_configs:
+      - targets: ["host.metrics.internal:9100"]
+        labels:
+          host_scope: root
+
+  - job_name: cadvisor
+    static_configs:
+      - targets: ["root_cadvisor:8080"]
+        labels:
+          host_scope: root
+    metric_relabel_configs:
+      - source_labels: [container_label_oakestra_logging_collector]
+        regex: root
+        action: keep
+      - source_labels: [container_label_com_docker_compose_service]
+        target_label: compose_service
+      - source_labels: [container_label_oakestra_cluster_id]
+        target_label: cluster_id
+      - regex: "container_label_.+"
+        action: labeldrop

--- a/run-a-cluster/root-orchestrator.yml
+++ b/run-a-cluster/root-orchestrator.yml
@@ -115,6 +115,141 @@ services:
       - "6379:6379"
     command: redis-server --requirepass rootRedis
 
+  prometheus:
+    image: prom/prometheus:v3.13.2-distroless
+    container_name: root_prometheus
+    hostname: root_prometheus
+    labels: *root-log-labels
+    expose:
+      - "9090"
+    volumes:
+      - ./prometheus/prometheus-root.yml:/etc/prometheus/prometheus.yml:ro
+      - root_prometheus_data:/prometheus
+    command:
+      - --config.file=/etc/prometheus/prometheus.yml
+      - --storage.tsdb.path=/prometheus
+      - --storage.tsdb.retention.time=7d
+      - --storage.tsdb.retention.size=1GB
+    depends_on:
+      - node_exporter
+      - cadvisor
+    extra_hosts:
+      - host.metrics.internal=${ROOT_METRICS_GATEWAY:-172.30.250.1}
+    networks:
+      - default
+      - metrics
+    read_only: true
+    tmpfs:
+      - /tmp
+    cap_drop:
+      - ALL
+    security_opt:
+      - no-new-privileges:true
+    restart: unless-stopped
+    logging: *default-logging
+
+  node_exporter:
+    image: quay.io/prometheus/node-exporter:v1.12.1
+    container_name: root_node_exporter
+    hostname: root_node_exporter
+    labels: *root-log-labels
+    network_mode: host
+    command:
+      - --path.procfs=/host/proc
+      - --path.sysfs=/host/sys
+      - --path.rootfs=/host
+      - --collector.filesystem.mount-points-exclude=^/(dev|proc|sys|var/lib/docker/.+|var/lib/containers/storage/.+)($$|/)
+      - --web.listen-address=${ROOT_METRICS_GATEWAY:-172.30.250.1}:9100
+      - --web.max-requests=5
+    volumes:
+      - type: bind
+        source: /proc
+        target: /host/proc
+        read_only: true
+        bind:
+          create_host_path: false
+      - type: bind
+        source: /sys
+        target: /host/sys
+        read_only: true
+        bind:
+          create_host_path: false
+      - type: bind
+        source: /
+        target: /host
+        read_only: true
+        bind:
+          propagation: rslave
+    read_only: true
+    cap_drop:
+      - ALL
+    security_opt:
+      - no-new-privileges:true
+    restart: unless-stopped
+    logging: *default-logging
+
+  cadvisor:
+    image: ghcr.io/google/cadvisor:v0.60.5
+    container_name: root_cadvisor
+    hostname: root_cadvisor
+    labels: *root-log-labels
+    ports:
+      - "127.0.0.1:8081:8080"
+    command:
+      - --docker_only=true
+      - --store_container_labels=false
+      - --whitelisted_container_labels=com.docker.compose.service,oakestra.cluster.id,oakestra.logging.collector
+      - --enable_metrics=cpu,disk,diskIO,memory,network
+      - --housekeeping_interval=10s
+      - --max_housekeeping_interval=15s
+      - --storage_duration=1m
+    volumes:
+      - type: bind
+        source: /
+        target: /rootfs
+        read_only: true
+        bind:
+          propagation: rslave
+      - type: bind
+        source: /sys
+        target: /sys
+        read_only: true
+        bind:
+          create_host_path: false
+      - type: bind
+        source: /var/run/docker.sock
+        target: /var/run/docker.sock
+        read_only: true
+        bind:
+          create_host_path: false
+      - type: bind
+        source: ${CONTAINERD_SOCKET:-/run/containerd/containerd.sock}
+        target: ${CONTAINERD_SOCKET:-/run/containerd/containerd.sock}
+        read_only: true
+        bind:
+          create_host_path: false
+      - type: bind
+        source: ${DOCKER_ROOT_DIR:-/var/lib/docker}
+        target: ${DOCKER_ROOT_DIR:-/var/lib/docker}
+        read_only: true
+        bind:
+          create_host_path: false
+      - type: bind
+        source: /dev/disk
+        target: /dev/disk
+        read_only: true
+        bind:
+          create_host_path: false
+    read_only: true
+    tmpfs:
+      - /tmp
+    cap_drop:
+      - ALL
+    security_opt:
+      - no-new-privileges:true
+    restart: unless-stopped
+    logging: *default-logging
+
   # Observability Stack
   grafana:
     image: grafana/grafana
@@ -124,6 +259,7 @@ services:
     ports:
       - 3000:3000
     environment:
+      - PROMETHEUS_URL=http://root_prometheus:9090
       - OAKESTRA_ALERT_CONTACT_POINT=${OAKESTRA_ALERT_CONTACT_POINT:-Oakestra Alert Webhook}
       - OAKESTRA_ALERT_WEBHOOK_URL=${OAKESTRA_ALERT_WEBHOOK_URL:-http://127.0.0.1:65535/oakestra-alerts}
       - OAKESTRA_ALERT_EMAIL_TO=${OAKESTRA_ALERT_EMAIL_TO:-alerts@example.invalid}
@@ -234,6 +370,12 @@ services:
 networks:
   default:
     name: oakestra
+  metrics:
+    internal: true
+    ipam:
+      config:
+        - subnet: ${ROOT_METRICS_SUBNET:-172.30.250.0/24}
+          gateway: ${ROOT_METRICS_GATEWAY:-172.30.250.1}
 
 volumes:
   mongodb_data:
@@ -243,4 +385,6 @@ volumes:
   alloy_data:
     driver: local
   loki_data:
+    driver: local
+  root_prometheus_data:
     driver: local

--- a/scripts/StartOakestraRoot.sh
+++ b/scripts/StartOakestraRoot.sh
@@ -78,7 +78,7 @@ curl -sfL https://raw.githubusercontent.com/oakestra/oakestra/$OAKESTRA_VERSION/
 curl -sfL https://raw.githubusercontent.com/oakestra/oakestra/$OAKESTRA_VERSION/root_orchestrator/override-images-only.yml > override-root-images-only.yml
 
 chmod +x downloadConfigFiles.sh
-./downloadConfigFiles.sh run-a-cluster $OAKESTRA_VERSION
+./downloadConfigFiles.sh root_orchestrator $OAKESTRA_VERSION
 
 #If additional override files provided, download them
 OAK_OVERRIDES=''

--- a/scripts/utils/downloadConfigFiles.sh
+++ b/scripts/utils/downloadConfigFiles.sh
@@ -1,19 +1,80 @@
 #!/bin/bash
 
-config_files="prometheus/prometheus.yml mosquitto/mosquitto.conf config/grafana-dashboards.yml config/grafana-datasources.yml config/loki.yml config/config.alloy config/alerts/grafana-rules.yml config/alerts/grafana-contact-point.yml config/dashboards/logs-dashboard.json config/dashboards/log-statistics-dashboard.json"
-repo_folder=$1
-repo_branch=$2
+set -u
 
-mkdir -p config/alerts 2> /dev/null
-mkdir -p config/dashboards 2> /dev/null
-mkdir prometheus 2> /dev/null
-mkdir mosquitto 2> /dev/null
+repo_folder=${1:?"repository folder is required"}
+repo_branch=${2:?"repository branch or tag is required"}
+
+metrics_disabled() {
+    case ",${OVERRIDE_FILES:-}," in
+        *override-no-observe*) return 0 ;;
+        *) return 1 ;;
+    esac
+}
+
+check_metrics_compatibility() {
+    if metrics_disabled; then
+        return 0
+    fi
+
+    if [ "$(uname -s)" != "Linux" ]; then
+        echo "Error: the host metrics stack requires Linux. Use override-no-observe.yml on unsupported hosts."
+        return 1
+    fi
+
+    local docker_version docker_major
+    docker_version=$(sudo docker version --format '{{.Server.Version}}' 2>/dev/null) || {
+        echo "Error: unable to read the Docker Engine server version."
+        return 1
+    }
+    docker_major=${docker_version%%.*}
+    docker_major=${docker_major#v}
+
+    if ! [[ "$docker_major" =~ ^[0-9]+$ ]] || [ "$docker_major" -lt 25 ]; then
+        echo "Error: the metrics stack requires Docker Engine 25 or newer (found ${docker_version:-unknown})."
+        echo "Use override-no-observe.yml to run Oakestra without the observability stack."
+        return 1
+    fi
+}
+
+download_file() {
+    local config_file=$1
+    local destination=$config_file
+    local temporary="${destination}.tmp.$$"
+    local url="https://raw.githubusercontent.com/oakestra/oakestra/${repo_branch}/${repo_folder}/${config_file}"
+
+    mkdir -p "$(dirname "$destination")"
+    if ! curl -fsSL "$url" -o "$temporary"; then
+        rm -f "$temporary"
+        echo "Error: failed to download $url"
+        return 1
+    fi
+    mv "$temporary" "$destination"
+}
+
+common_config_files="config/grafana-dashboards.yml config/grafana-datasources.yml config/loki.yml config/config.alloy config/alerts/grafana-rules.yml config/alerts/grafana-contact-point.yml config/dashboards/logs-dashboard.json config/dashboards/log-statistics-dashboard.json"
+
+case "$repo_folder" in
+    root_orchestrator)
+        config_files="prometheus/prometheus.yml $common_config_files"
+        ;;
+    cluster_orchestrator)
+        config_files="prometheus/prometheus.yml prometheus/prometheus-host.yml mosquitto/mosquitto.conf $common_config_files"
+        ;;
+    run-a-cluster)
+        config_files="prometheus/prometheus.yml prometheus/prometheus-root.yml mosquitto/mosquitto.conf $common_config_files"
+        ;;
+    *)
+        echo "Error: unsupported configuration folder: $repo_folder"
+        exit 1
+        ;;
+esac
+
+check_metrics_compatibility || exit 1
 
 # Remove the retired combined logs and statistics dashboard.
 rm -f config/dashboards/dashboard.json
 
-for config_file in ${config_files}; do
-    rm $config_file 2> /dev/null
-    touch $config_file 
-    curl -sL https://raw.githubusercontent.com/oakestra/oakestra/$repo_branch/$repo_folder/$config_file -o $config_file
+for config_file in $config_files; do
+    download_file "$config_file" || exit 1
 done


### PR DESCRIPTION
> [!NOTE]
> This PR depends on #574 and is based on that PR's branch.
> Please review and merge #574 first.

## Summary

This PR adds host and container metrics collection to Root, Cluster, and 1-DOC deployments using Prometheus, node_exporter, and cAdvisor. Each deployment stores metrics locally with seven-day/1-GB retention and provisions a non-default Grafana datasource with UID `Prometheus`.

Prometheus and node_exporter remain internal. cAdvisor exposes its diagnostics and `/metrics` endpoint on loopback ports `8081` for Root/1-DOC and `8082` for Cluster. The implementation also covers host-network, IPv6, images-only, and no-observe configurations, including the maintained `run-a-cluster/root-orchestrator.yml` manifest.

**Migration note**: Cluster Prometheus is now named cluster_prometheus and port 10009 is no longer published in normal bridge mode. Grafana accesses it through the private Docker network; the host-network override exposes it only on 127.0.0.1:10009.

Fixes #535