### PR TITLE
Communicate explicitly configured NodeEngine public IP to NetManager in handshake

### DIFF
--- a/go_node_engine/internal/daemon/nodeengined.go
+++ b/go_node_engine/internal/daemon/nodeengined.go
@@ -102,7 +102,7 @@ func main() {
 		// wait for systemctl to start the netmanager service
 		logger.InfoLogger().Printf("Waiting for NetManager to start...")
 		time.Sleep(5 * time.Second)
-		err := requests.RegisterSelfToNetworkComponent()
+		err := requests.RegisterSelfToNetworkComponent(configs)
 		if err != nil {
 			logger.ErrorLogger().Fatalf("Error registering to NetManager: %v", err)
 		}

--- a/go_node_engine/requests/NetManagerRequests.go
+++ b/go_node_engine/requests/NetManagerRequests.go
@@ -5,6 +5,7 @@ import (
 	"context"
 	"encoding/json"
 	"fmt"
+	"go_node_engine/config"
 	"go_node_engine/model"
 	"net"
 	"net/http"
@@ -13,8 +14,9 @@ import (
 )
 
 type registerRequest struct {
-	ClientId       string `json:"client_id"`
-	ClusterAddress string `json:"cluster_address"`
+	ClientId          string `json:"client_id"`
+	ClusterAddress    string `json:"cluster_address"`
+	NodePublicAddress string `json:"node_public_address"`
 }
 
 type connectNetworkRequest struct {
@@ -95,10 +97,16 @@ func DetachNetworkFromTask(servicename string, instance int) error {
 }
 
 // RegisterSelfToNetworkComponent registers the node to the network component
-func RegisterSelfToNetworkComponent() error {
+func RegisterSelfToNetworkComponent(configs config.ConfFile) error {
+	publicIp := ""
+	if !configs.PublicIp.IsAuto() && !configs.PublicIp.IsDisabled() {
+		publicIp = configs.PublicIp.Value()
+	}
+
 	request := registerRequest{
-		ClientId:       model.GetNodeInfo().Id,
-		ClusterAddress: model.GetNodeInfo().ClusterAddress,
+		ClientId:          model.GetNodeInfo().Id,
+		ClusterAddress:    model.GetNodeInfo().ClusterAddress,
+		NodePublicAddress: publicIp,
 	}
 	jsonReq, err := json.Marshal(request)
 	if err != nil {


### PR DESCRIPTION
Fixes [oakestra-net/#250](https://github.com/oakestra/oakestra-net/issues/250).

This PR allows NetManager to use the explicit public IP configured in the NodeEngine config when it doesn't have an explicit public IP configured itself. This avoids the requirement to configure the public IP twice in both configs.

Requires [oakestra-net/#252](https://github.com/oakestra/oakestra-net/pull/252) to be merged together with this PR.