### PR TITLE
fix: remove FLASK_DEBUG and FLASK_ENV from resource-abstractor Docker…

### DIFF
--- a/resource-abstractor/Dockerfile
+++ b/resource-abstractor/Dockerfile
@@ -7,9 +7,7 @@ RUN pip install --no-cache-dir -r requirements.txt
 
 COPY . /
 
-# TRUE for verbose logging
-ENV FLASK_ENV=development
-ENV FLASK_DEBUG=TRUE
+
 ENV LOG_LEVEL=WARNING
 
 ENV MONGO_URL=localhost

--- a/resource-abstractor/Dockerfile
+++ b/resource-abstractor/Dockerfile
@@ -7,7 +7,6 @@ RUN pip install --no-cache-dir -r requirements.txt
 
 COPY . /
 
-
 ENV LOG_LEVEL=WARNING
 
 ENV MONGO_URL=localhost


### PR DESCRIPTION
## What this PR does
Removes `FLASK_ENV=development` and `FLASK_DEBUG=TRUE` from `resource-abstractor/Dockerfile`. These were leftover debug settings baked into the image, which meant the container always ran in Flask's debug mode by default a performance and security concern (debug mode exposes an interactive debugger and stack traces).

Other services (system-manager, cluster-manager) already have `FLASK_DEBUG=FALSE`, so `resource-abstractor` was the odd one out.

Logging is already controlled separately via `LOG_LEVEL`, so no functionality is lost.  only the unnecessary debug flags are removed.

Confirmed with @robertjndw before opening this PR.

Fixes #587